### PR TITLE
unzip: add function unzOpenBuffer

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -19,6 +19,7 @@ libminizip_la_SOURCES = \
 	ioapi.c \
 	unzip.c \
 	zip.c \
+	ioapi_mem.c \
 	${iowin32_src}
 
 libminizip_la_LDFLAGS = $(AM_LDFLAGS) -version-info 1:0:0 -lz

--- a/unzip.c
+++ b/unzip.c
@@ -26,6 +26,7 @@
 
 #include "zlib.h"
 #include "unzip.h"
+#include "ioapi_mem.h"
 
 #ifdef STDC
 #  include <stddef.h>
@@ -579,6 +580,16 @@ extern unzFile ZEXPORT unzOpen(const char *path)
 extern unzFile ZEXPORT unzOpen64(const void *path)
 {
     return unzOpenInternal(path, NULL, 1);
+}
+
+extern unzFile ZEXPORT unzOpenBuffer(const  void* buffer, uLong size)
+{
+    char path[48] = {0};
+    ourmemory_t FileMemory;
+    zlib_filefunc64_32_def memory_file;
+    sprintf(path, "%llx %lx", (unsigned long long)buffer, (unsigned long)size);
+    fill_memory_filefunc(&memory_file, &FileMemory);
+    return unzOpenInternal(path, &memory_file, 0);
 }
 
 extern int ZEXPORT unzClose(unzFile file)

--- a/unzip.h
+++ b/unzip.h
@@ -143,6 +143,8 @@ extern unzFile ZEXPORT unzOpen64 OF((const void *path));
    open64_file_func callback. Under Windows, if UNICODE is defined, using fill_fopen64_filefunc, the path 
    is a pointer to a wide unicode string  (LPCTSTR is LPCWSTR), so const char* does not describe the reality */
 
+extern unzFile ZEXPORT unzOpenBuffer OF((const void* buffer, uLong size));
+/* Open a Zip file, like unzOpen, but from a buffer */
 extern unzFile ZEXPORT unzOpen2 OF((const char *path, zlib_filefunc_def* pzlib_filefunc_def));
 /* Open a Zip file, like unzOpen, but provide a set of file low level API for read/write operations */
 extern unzFile ZEXPORT unzOpen2_64 OF((const void *path, zlib_filefunc64_def* pzlib_filefunc_def));


### PR DESCRIPTION
Hey @nmoinvaz,

Thanks for merging all the patches on the mailing list. :)
Really picking up the slack :D

I work on the opensource cocos2d-x game engine and minizip is a depend.
Your repo will really help as the current version is like a miss mash of patches 
with random custom namespaces that someone decided to add.

Any way I want the team to switch to using your repo as the upstream as it is the most up to date 
but this function is needed by the game engine to support newer features.

Could you give me some feedback and hopefully we could possible merge this?
