### PR TITLE
Fix linking on NetBSD and DragonFly BSD.

### DIFF
--- a/ioapi.h
+++ b/ioapi.h
@@ -38,7 +38,7 @@
 #  define ftello64 ftell
 #  define fseeko64 fseek
 #else
-#  ifdef __FreeBSD__
+#  if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__DragonFly__) || defined(__OpenBSD__)
 #    define fopen64 fopen
 #    define ftello64 ftello
 #    define fseeko64 fseeko


### PR DESCRIPTION
On these operating systems fopen, fseek, and ftello are 64-bit
filesize safe.

Signed-off-by: Thomas Klausner <wiz@NetBSD.org>