### PR TITLE
Add a make file for aes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+*.o
+libaes.a
+libz.a
+minizip
+miniunz
+tags
+cscope.files
+cscope.out
+*.swp
+*.swo

--- a/aes/Makefile
+++ b/aes/Makefile
@@ -1,0 +1,19 @@
+CC=cc
+CFLAGS=-O -DHAVE_AES
+OBJS=aescrypt.o aeskey.o aestab.o entropy.o fileenc.o hmac.o prng.o pwd2key.o sha1.o
+ARFLAGS=rv
+
+.c.o:
+	$(CC) -c $(CFLAGS) $*.c
+
+libaes.a: $(OBJS)
+	$(ECHO) $(AR) $(ARFLAGS) ../libaes.a $?
+	$(AR) $(ARFLAGS) ../libaes.a $?
+	$(RANLIB) ../libaes.a
+
+all: libaes.a
+
+.PHONY: clean
+
+clean:
+	rm *.o *.a

--- a/aes/entropy.c
+++ b/aes/entropy.c
@@ -1,5 +1,8 @@
 #ifdef _WIN32
 #include <windows.h>
+#else
+#include <sys/stat.h>
+#include <fcntl.h>
 #endif
 
 #if defined(__cplusplus)

--- a/minizip.c
+++ b/minizip.c
@@ -201,6 +201,11 @@ void do_help()
            "  -1  Compress faster\n" \
            "  -9  Compress better\n\n" \
            "  -j  exclude path. store only the file name.\n\n");
+#ifdef CONST_SALT
+#define STR(x) #x
+#define STRINGIFY(x) STR(x)
+    printf("Compiled with constant salt: '%s'\n\n", STRINGIFY(CONST_SALT));
+#endif
 }
 
 int main(int argc, char *argv[])
@@ -338,9 +343,14 @@ int main(int argc, char *argv[])
         int zip64 = 0;
 
         /* Skip command line options */
-        if ((((*(argv[i])) == '-') || ((*(argv[i])) == '/')) && (strlen(argv[i]) == 2) &&
-            (argv[i][1] == 'o') || (argv[i][1] == 'O') || (argv[i][1] == 'a') || (argv[i][1] == 'A') ||
-            (argv[i][1] == 'p') || (argv[i][1] == 'P') || ((argv[i][1] >= '0') && (argv[i][1] <= '9')))
+        if (
+                (
+                 ((*(argv[i])) == '-') || ((*(argv[i])) == '/')) && (strlen(argv[i]) == 2) &&
+                (
+                 (argv[i][1] == 'o') || (argv[i][1] == 'O') || (argv[i][1] == 'a') || (argv[i][1] == 'A') ||
+                 (argv[i][1] == 'p') || (argv[i][1] == 'P') || ((argv[i][1] >= '0') && (argv[i][1] <= '9'))
+                )
+           )
             continue;
 
         /* Get information about the file on disk so we can store it in zip */

--- a/unix.mk
+++ b/unix.mk
@@ -1,8 +1,10 @@
 CC=cc
-CFLAGS=-O -I../..
+CFLAGS=-O -I../.. -DHAVE_AES #-DCONST_SALT=constant_salt
 
-UNZ_OBJS = miniunz.o unzip.o ioapi.o ../../libz.a
-ZIP_OBJS = minizip.o zip.o   ioapi.o ../../libz.a
+# use CONST_SALT to save unzip time
+
+UNZ_OBJS = miniunz.o unzip.o ioapi.o libz.a libaes.a
+ZIP_OBJS = minizip.o zip.o   ioapi.o libz.a libaes.a
 TEST_FILES = test.zip readme.old readme.txt
 
 .c.o:
@@ -10,10 +12,13 @@ TEST_FILES = test.zip readme.old readme.txt
 
 all: miniunz minizip
 
-miniunz:  $(UNZ_OBJS)
+libaes.a:
+	cd aes; $(MAKE) $(MFLAGS)
+
+miniunz:  $(UNZ_OBJS) libaes.a
 	$(CC) $(CFLAGS) -o $@ $(UNZ_OBJS)
 
-minizip:  $(ZIP_OBJS)
+minizip:  $(ZIP_OBJS) libaes.a
 	$(CC) $(CFLAGS) -o $@ $(ZIP_OBJS)
 
 .PHONY: test clean

--- a/zip.c
+++ b/zip.c
@@ -1277,10 +1277,23 @@ extern int ZEXPORT zipOpenNewFileInZip4_64(zipFile file, const char* filename, c
                 return Z_ERRNO;
 
             saltlength = SALT_LENGTH(AES_ENCRYPTIONMODE);
-
+#ifdef CONST_SALT
+#define STR(x) #x
+#define STRINGIFY(x) STR(x)
+            const char * csalt = STRINGIFY(CONST_SALT);
+            int clen = strlen(csalt);
+            for (int i = 0; i < saltlength; i++)
+            {
+                if (i < clen)
+                    saltvalue[i] = csalt[i];
+                else
+                    saltvalue[i] = 0;
+            }
+#else
             prng_init(entropy_fun, zi->ci.aes_rng);
             prng_rand(saltvalue, saltlength, zi->ci.aes_rng);
             prng_end(zi->ci.aes_rng);
+#endif
 
             fcrypt_init(AES_ENCRYPTIONMODE, password, strlen(password), saltvalue, passverify, &zi->ci.aes_ctx);
 


### PR DESCRIPTION
Fix a bug in minizip's command line option parsing code.
Fix a issue in aes when building on unix like system
Add marco to use constant salt to save unzip time.