### PR TITLE
Fix use-of-uninitialized-value warning.

### DIFF
--- a/unzip.c
+++ b/unzip.c
@@ -198,6 +198,7 @@ local int unz64local_getByte(const zlib_filefunc64_32_def* pzlib_filefunc_def, v
         *pi = (int)c;
         return UNZ_OK;
     }
+    *pi = 0;
     if (ZERROR64(*pzlib_filefunc_def, filestream))
         return UNZ_ERRNO;
     return UNZ_EOF;


### PR DESCRIPTION
UNZ_EOF and UNZ_OK are both zero, so the caller of unzlocal_getByte has no way to know whether or not pi points to data or garbage. This change makes it point to zero in the EOF case. While it might be better to indicate an error immediately, that would be a more significant change. The library ought to be just as good at handling an erroneous zero byte as anything else; and this way dynamic analysis tools won't complain about use-of-uninitialized-value when reading a malformed file.