### PR TITLE
Assignment from incompatible pointer type

### DIFF
--- a/unzip.c
+++ b/unzip.c
@@ -1276,7 +1276,7 @@ extern int ZEXPORT unzOpenCurrentFile3(unzFile file, int* method, int* level, in
 #endif
         {
             int i;
-            s->pcrc_32_tab = (const unsigned long*)get_crc_table();
+            s->pcrc_32_tab = (const unsigned int*)get_crc_table();
             init_keys(password, s->keys, s->pcrc_32_tab);
 
             if (ZREAD64(s->z_filefunc, s->filestream, source, 12) < 12)


### PR DESCRIPTION
Fix the error "assignment from incompatible pointer type" when built on Linux platform.