### PR TITLE
Fixed ZLIB headers not being found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,8 +18,9 @@ project("minizip")
 # set cmake debug postfix to d
 set(CMAKE_DEBUG_POSTFIX "d")
 
-if(BUILD_TEST OR BUILD_SHARED_LIBS)
-   find_package(ZLIB REQUIRED)
+find_package(ZLIB REQUIRED)
+if(ZLIB_FOUND)
+    include_directories(${ZLIB_INCLUDE_DIRS})
 endif()
 
 set(MINIZIP_SRC "ioapi.c"


### PR DESCRIPTION
Fixed ZLIB headers not being found if it's not in a default include location