### PR TITLE
Added ability to specify ZLIB_ROOT when using CMAKE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,10 @@ project("minizip")
 # set cmake debug postfix to d
 set(CMAKE_DEBUG_POSTFIX "d")
 
+# Ensure correct version of zlib is referenced
+set(ZLIB_ROOT ${DEF_ZLIB_ROOT} CACHE PATH "Parent directory of zlib installation")
+include_directories(${ZLIB_ROOT}/include)
+
 if(BUILD_TEST OR BUILD_SHARED_LIBS)
    find_package(ZLIB REQUIRED)
 endif()


### PR DESCRIPTION
I'm experimenting with different versions of zlib (Intel/Kukunas, CloudFlare etc.) and I found it useful to be able to link minizip with a particular version out of those that I have available. I've modified the CMakeLists.txt to make this straightforward to do.