### PR TITLE
Moved some higher-level subrotuines into zip.c and unzip.c

### DIFF
--- a/miniunz.c
+++ b/miniunz.c
@@ -14,163 +14,25 @@
    See the accompanying LICENSE file for the full text of the license.
 */
 
-#if (!defined(_WIN32)) && (!defined(WIN32)) && (!defined(__APPLE__))
-#  ifndef __USE_FILE_OFFSET64
-#    define __USE_FILE_OFFSET64
-#  endif
-#  ifndef __USE_LARGEFILE64
-#    define __USE_LARGEFILE64
-#  endif
-#  ifndef _LARGEFILE64_SOURCE
-#    define _LARGEFILE64_SOURCE
-#  endif
-#  ifndef _FILE_OFFSET_BIT
-#    define _FILE_OFFSET_BIT 64
-#  endif
-#endif
-
-#ifdef __APPLE__
-/* In darwin and perhaps other BSD variants off_t is a 64 bit value, hence no need for specific 64 bit functions */
-#  define FOPEN_FUNC(filename, mode) fopen(filename, mode)
-#  define FTELLO_FUNC(stream) ftello(stream)
-#  define FSEEKO_FUNC(stream, offset, origin) fseeko(stream, offset, origin)
-#else
-#  define FOPEN_FUNC(filename, mode) fopen64(filename, mode)
-#  define FTELLO_FUNC(stream) ftello64(stream)
-#  define FSEEKO_FUNC(stream, offset, origin) fseeko64(stream, offset, origin)
-#endif
-
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <time.h>
-#include <errno.h>
-#include <fcntl.h>
-
-#ifdef _WIN32
-#  include <direct.h>
-#  include <io.h>
-#else
-#  include <sys/stat.h>
-#  include <unistd.h>
-#  include <utime.h>
-#endif
-
-#ifdef _WIN32
-#  define MKDIR(d) _mkdir(d)
-#  define CHDIR(d) _chdir(d)
-#else
-#  define MKDIR(d) mkdir(d, 0775)
-#  define CHDIR(d) chdir(d)
-#endif
 
 #include "unzip.h"
 
-#define WRITEBUFFERSIZE (8192)
-#define MAXFILENAME     (256)
-
-#ifdef _WIN32
-#  define USEWIN32IOAPI
-#  include "iowin32.h"
-#endif
-
-void change_file_date(const char *filename, uLong dosdate, tm_unz tmu_date)
+void do_banner()
 {
-#ifdef _WIN32
-    HANDLE hFile;
-    FILETIME ftm, ftLocal, ftCreate, ftLastAcc, ftLastWrite;
-
-    hFile = CreateFileA(filename, GENERIC_READ | GENERIC_WRITE, 0, NULL, OPEN_EXISTING, 0, NULL);
-    if (hFile != INVALID_HANDLE_VALUE)
-    {
-        GetFileTime(hFile, &ftCreate, &ftLastAcc, &ftLastWrite);
-        DosDateTimeToFileTime((WORD)(dosdate>>16),(WORD)dosdate, &ftLocal);
-        LocalFileTimeToFileTime(&ftLocal, &ftm);
-        SetFileTime(hFile, &ftm, &ftLastAcc, &ftm);
-        CloseHandle(hFile);
-    }
-#else
-#if defined unix || defined __APPLE__
-    struct utimbuf ut;
-    struct tm newdate;
-
-    newdate.tm_sec = tmu_date.tm_sec;
-    newdate.tm_min = tmu_date.tm_min;
-    newdate.tm_hour = tmu_date.tm_hour;
-    newdate.tm_mday = tmu_date.tm_mday;
-    newdate.tm_mon = tmu_date.tm_mon;
-    if (tmu_date.tm_year > 1900)
-        newdate.tm_year = tmu_date.tm_year - 1900;
-    else
-        newdate.tm_year = tmu_date.tm_year ;
-    newdate.tm_isdst = -1;
-
-    ut.actime = ut.modtime = mktime(&newdate);
-    utime(filename,&ut);
-#endif
-#endif
+    printf("MiniUnz 1.01b, demo of zLib + Unz package written by Gilles Vollant\n");
+    printf("more info at http://www.winimage.com/zLibDll/minizip.html\n\n");
 }
 
-int check_file_exists(const char* filename)
+void do_help()
 {
-    FILE* ftestexist = FOPEN_FUNC(filename,"rb");
-    if (ftestexist == NULL)
-        return 0;
-    fclose(ftestexist);
-    return 1;
-}
-
-int makedir(const char *newdir)
-{
-    char *buffer = NULL;
-    char *p = NULL;
-    int len = (int)strlen(newdir);
-
-    if (len <= 0)
-        return 0;
-
-    buffer = (char*)malloc(len+1);
-    if (buffer == NULL)
-    {
-        printf("Error allocating memory\n");
-        return UNZ_INTERNALERROR;
-    }
-
-    strcpy(buffer, newdir);
-
-    if (buffer[len-1] == '/')
-        buffer[len-1] = 0;
-
-    if (MKDIR(buffer) == 0)
-    {
-        free(buffer);
-        return 1;
-    }
-
-    p = buffer + 1;
-    while (1)
-    {
-        char hold;
-        while(*p && *p != '\\' && *p != '/')
-            p++;
-        hold = *p;
-        *p = 0;
-
-        if ((MKDIR(buffer) == -1) && (errno == ENOENT))
-        {
-            printf("couldn't create directory %s (%d)\n", buffer, errno);
-            free(buffer);
-            return 0;
-        }
-
-        if (hold == 0)
-            break;
-
-        *p++ = hold;
-    }
-
-    free(buffer);
-    return 1;
+    printf("Usage : miniunz [-e] [-x] [-v] [-l] [-o] [-p password] file.zip [file_to_extr.] [-d extractdir]\n\n" \
+           "  -e  Extract without pathname (junk paths)\n" \
+           "  -x  Extract with pathname\n" \
+           "  -v  list files\n" \
+           "  -l  list files\n" \
+           "  -d  directory to extract into\n" \
+           "  -o  overwrite files without prompting\n" \
+           "  -p  extract crypted file using password\n\n");
 }
 
 void display_zpos64(ZPOS64_T n, int size_char)
@@ -196,24 +58,6 @@ void display_zpos64(ZPOS64_T n, int size_char)
     while (size_char-- > size_display_string)
         printf(" ");
     printf("%s",&number[pos_string]);
-}
-
-void do_banner()
-{
-    printf("MiniUnz 1.01b, demo of zLib + Unz package written by Gilles Vollant\n");
-    printf("more info at http://www.winimage.com/zLibDll/minizip.html\n\n");
-}
-
-void do_help()
-{
-    printf("Usage : miniunz [-e] [-x] [-v] [-l] [-o] [-p password] file.zip [file_to_extr.] [-d extractdir]\n\n" \
-           "  -e  Extract without pathname (junk paths)\n" \
-           "  -x  Extract with pathname\n" \
-           "  -v  list files\n" \
-           "  -l  list files\n" \
-           "  -d  directory to extract into\n" \
-           "  -o  overwrite files without prompting\n" \
-           "  -p  extract crypted file using password\n\n");
 }
 
 int do_list(unzFile uf)
@@ -288,181 +132,6 @@ int do_list(unzFile uf)
     }
 
     return 0;
-}
-
-int do_extract_currentfile(unzFile uf, int opt_extract_without_path, int* popt_overwrite, const char *password)
-{
-    unz_file_info64 file_info = {0};
-    FILE* fout = NULL;
-    void* buf = NULL;
-    uInt size_buf = WRITEBUFFERSIZE;
-    int err = UNZ_OK;
-    int errclose = UNZ_OK;
-    int skip = 0;
-    char filename_inzip[256] = {0};
-    char* filename_withoutpath = NULL;
-    const char* write_filename = NULL;
-    char* p = NULL;
-
-    err = unzGetCurrentFileInfo64(uf, &file_info, filename_inzip, sizeof(filename_inzip), NULL, 0, NULL, 0);
-    if (err != UNZ_OK)
-    {
-        printf("error %d with zipfile in unzGetCurrentFileInfo\n",err);
-        return err;
-    }
-
-    p = filename_withoutpath = filename_inzip;
-    while (*p != 0)
-    {
-        if ((*p == '/') || (*p == '\\'))
-            filename_withoutpath = p+1;
-        p++;
-    }
-
-    /* If zip entry is a directory then create it on disk */
-    if (*filename_withoutpath == 0)
-    {
-        if (opt_extract_without_path == 0)
-        {
-            printf("creating directory: %s\n", filename_inzip);
-            MKDIR(filename_inzip);
-        }
-        return err;
-    }
-
-    buf = (void*)malloc(size_buf);
-    if (buf == NULL)
-    {
-        printf("Error allocating memory\n");
-        return UNZ_INTERNALERROR;
-    }
-
-    err = unzOpenCurrentFilePassword(uf, password);
-    if (err != UNZ_OK)
-        printf("error %d with zipfile in unzOpenCurrentFilePassword\n", err);
-
-    if (opt_extract_without_path)
-        write_filename = filename_withoutpath;
-    else
-        write_filename = filename_inzip;
-
-    /* Determine if the file should be overwritten or not and ask the user if needed */
-    if ((err == UNZ_OK) && (*popt_overwrite == 0) && (check_file_exists(write_filename)))
-    {
-        char rep = 0;
-        do
-        {
-            char answer[128];
-            printf("The file %s exists. Overwrite ? [y]es, [n]o, [A]ll: ", write_filename);
-            if (scanf("%1s", answer) != 1)
-                exit(EXIT_FAILURE);
-            rep = answer[0];
-            if ((rep >= 'a') && (rep <= 'z'))
-                rep -= 0x20;
-        }
-        while ((rep != 'Y') && (rep != 'N') && (rep != 'A'));
-
-        if (rep == 'N')
-            skip = 1;
-        if (rep == 'A')
-            *popt_overwrite = 1;
-    }
-
-    /* Create the file on disk so we can unzip to it */
-    if ((skip == 0) && (err == UNZ_OK))
-    {
-        fout = FOPEN_FUNC(write_filename, "wb");
-        /* Some zips don't contain directory alone before file */
-        if ((fout == NULL) && (opt_extract_without_path == 0) &&
-            (filename_withoutpath != (char*)filename_inzip))
-        {
-            char c = *(filename_withoutpath-1);
-            *(filename_withoutpath-1) = 0;
-            makedir(write_filename);
-            *(filename_withoutpath-1) = c;
-            fout = FOPEN_FUNC(write_filename, "wb");
-        }
-        if (fout == NULL)
-            printf("error opening %s\n", write_filename);
-    }
-
-    /* Read from the zip, unzip to buffer, and write to disk */
-    if (fout != NULL)
-    {
-        printf(" extracting: %s\n", write_filename);
-
-        do
-        {
-            err = unzReadCurrentFile(uf, buf, size_buf);
-            if (err < 0)
-            {
-                printf("error %d with zipfile in unzReadCurrentFile\n", err);
-                break;
-            }
-            if (err == 0)
-                break;
-            if (fwrite(buf, err, 1, fout) != 1)
-            {
-                printf("error %d in writing extracted file\n", errno);
-                err = UNZ_ERRNO;
-                break;
-            }
-        }
-        while (err > 0);
-
-        if (fout)
-            fclose(fout);
-
-        /* Set the time of the file that has been unzipped */
-        if (err == 0)
-            change_file_date(write_filename,file_info.dosDate, file_info.tmu_date);
-    }
-
-    errclose = unzCloseCurrentFile(uf);
-    if (errclose != UNZ_OK)
-        printf("error %d with zipfile in unzCloseCurrentFile\n", errclose);
-
-    free(buf);
-    return err;
-}
-
-int do_extract_all(unzFile uf, int opt_extract_without_path, int opt_overwrite, const char *password)
-{
-    int err = unzGoToFirstFile(uf);
-    if (err != UNZ_OK)
-    {
-        printf("error %d with zipfile in unzGoToFirstFile\n", err);
-        return 1;
-    }
-
-    do
-    {
-        err = do_extract_currentfile(uf, opt_extract_without_path, &opt_overwrite, password);
-        if (err != UNZ_OK)
-            break;
-        err = unzGoToNextFile(uf);
-    }
-    while (err == UNZ_OK);
-
-    if (err != UNZ_END_OF_LIST_OF_FILE)
-    {
-        printf("error %d with zipfile in unzGoToNextFile\n", err);
-        return 1;
-    }
-    return 0;
-}
-
-int do_extract_onefile(unzFile uf, const char* filename, int opt_extract_without_path, int opt_overwrite,
-    const char* password)
-{
-    if (unzLocateFile(uf, filename, NULL) != UNZ_OK)
-    {
-        printf("file %s not found in the zipfile\n", filename);
-        return 2;
-    }
-    if (do_extract_currentfile(uf, opt_extract_without_path, &opt_overwrite, password) == UNZ_OK)
-        return 0;
-    return 1;
 }
 
 int main(int argc, const char *argv[])

--- a/minizip.c
+++ b/minizip.c
@@ -59,133 +59,6 @@
 
 #include "zip.h"
 
-#ifdef _WIN32
-#  define USEWIN32IOAPI
-#  include "iowin32.h"
-#endif
-
-#define WRITEBUFFERSIZE (16384)
-#define MAXFILENAME     (256)
-
-uLong filetime(const char *filename, tm_zip *tmzip, uLong *dostime)
-{
-    int ret = 0;
-#ifdef _WIN32
-    FILETIME ftLocal;
-    HANDLE hFind;
-    WIN32_FIND_DATAA ff32;
-
-    hFind = FindFirstFileA(filename, &ff32);
-    if (hFind != INVALID_HANDLE_VALUE)
-    {
-        FileTimeToLocalFileTime(&(ff32.ftLastWriteTime), &ftLocal);
-        FileTimeToDosDateTime(&ftLocal,((LPWORD)dostime)+1,((LPWORD)dostime)+0);
-        FindClose(hFind);
-        ret = 1;
-    }
-#else
-#if defined unix || defined __APPLE__
-    struct stat s = {0};
-    struct tm* filedate;
-    time_t tm_t = 0;
-
-    if (strcmp(filename,"-") != 0)
-    {
-        char name[MAXFILENAME+1];
-        int len = strlen(filename);
-        if (len > MAXFILENAME)
-            len = MAXFILENAME;
-
-        strncpy(name, filename, MAXFILENAME - 1);
-        name[MAXFILENAME] = 0;
-
-        if (name[len - 1] == '/')
-            name[len - 1] = 0;
-
-        /* not all systems allow stat'ing a file with / appended */
-        if (stat(name,&s) == 0)
-        {
-            tm_t = s.st_mtime;
-            ret = 1;
-        }
-    }
-
-    filedate = localtime(&tm_t);
-
-    tmzip->tm_sec  = filedate->tm_sec;
-    tmzip->tm_min  = filedate->tm_min;
-    tmzip->tm_hour = filedate->tm_hour;
-    tmzip->tm_mday = filedate->tm_mday;
-    tmzip->tm_mon  = filedate->tm_mon ;
-    tmzip->tm_year = filedate->tm_year;
-#endif
-#endif
-    return ret;
-}
-
-int check_file_exists(const char* filename)
-{
-    FILE* ftestexist = FOPEN_FUNC(filename, "rb");
-    if (ftestexist == NULL)
-        return 0;
-    fclose(ftestexist);
-    return 1;
-}
-
-int is_large_file(const char* filename)
-{
-    ZPOS64_T pos = 0;
-    FILE* pFile = FOPEN_FUNC(filename, "rb");
-
-    if (pFile == NULL)
-        return 0;
-
-    FSEEKO_FUNC(pFile, 0, SEEK_END);
-    pos = FTELLO_FUNC(pFile);
-    fclose(pFile);
-
-    printf("File : %s is %lld bytes\n", filename, pos);
-
-    return (pos >= 0xffffffff);
-}
-
-/* Calculate the CRC32 of a file, because to encrypt a file, we need known the CRC32 of the file before */
-int get_file_crc(const char* filenameinzip, void *buf, unsigned long size_buf, unsigned long* result_crc)
-{
-    FILE *fin = NULL;
-    unsigned long calculate_crc = 0;
-    unsigned long size_read = 0;
-    int err = ZIP_OK;
-
-    fin = FOPEN_FUNC(filenameinzip,"rb");
-    if (fin == NULL)
-        err = ZIP_ERRNO;
-    else
-    {
-        do
-        {
-            size_read = (int)fread(buf,1,size_buf,fin);
-
-            if ((size_read < size_buf) && (feof(fin) == 0))
-            {
-                printf("error in reading %s\n",filenameinzip);
-                err = ZIP_ERRNO;
-            }
-
-            if (size_read > 0)
-                calculate_crc = crc32(calculate_crc,buf,size_read);
-        }
-        while ((err == ZIP_OK) && (size_read > 0));
-    }
-
-    if (fin)
-        fclose(fin);
-
-    printf("file %s crc %lx\n", filenameinzip, calculate_crc);
-    *result_crc = calculate_crc;
-    return err;
-}
-
 void do_banner()
 {
     printf("MiniZip 1.1, demo of zLib + MiniZip64 package, written by Gilles Vollant\n");
@@ -212,7 +85,7 @@ int main(int argc, char *argv[])
     char *zipfilename = NULL;
     const char* password = NULL;
     void* buf = NULL;
-    int size_buf = WRITEBUFFERSIZE;
+    int size_buf = minizip_get_writebuffersize();
     int zipfilenamearg = 0;
     int errclose = 0;
     int err = 0;

--- a/unzip.c
+++ b/unzip.c
@@ -43,6 +43,9 @@
 #  include <errno.h>
 #endif
 
+#define WRITEBUFFERSIZE (8192)
+#define MAXFILENAME     (256)
+
 #ifdef HAVE_AES
 #  define AES_METHOD          (99)
 #  define AES_PWVERIFYSIZE    (2)
@@ -1949,4 +1952,278 @@ extern int ZEXPORT unzeof(unzFile file)
     if (s->pfile_in_zip_read->rest_read_uncompressed == 0)
         return 1;
     return 0;
+}
+
+local void change_file_date(const char *filename, uLong dosdate, tm_unz tmu_date)
+{
+#ifdef _WIN32
+    HANDLE hFile;
+    FILETIME ftm, ftLocal, ftCreate, ftLastAcc, ftLastWrite;
+
+    hFile = CreateFileA(filename, GENERIC_READ | GENERIC_WRITE, 0, NULL, OPEN_EXISTING, 0, NULL);
+    if (hFile != INVALID_HANDLE_VALUE)
+    {
+        GetFileTime(hFile, &ftCreate, &ftLastAcc, &ftLastWrite);
+        DosDateTimeToFileTime((WORD)(dosdate>>16),(WORD)dosdate, &ftLocal);
+        LocalFileTimeToFileTime(&ftLocal, &ftm);
+        SetFileTime(hFile, &ftm, &ftLastAcc, &ftm);
+        CloseHandle(hFile);
+    }
+#else
+#if defined unix || defined __APPLE__
+    struct utimbuf ut;
+    struct tm newdate;
+
+    newdate.tm_sec = tmu_date.tm_sec;
+    newdate.tm_min = tmu_date.tm_min;
+    newdate.tm_hour = tmu_date.tm_hour;
+    newdate.tm_mday = tmu_date.tm_mday;
+    newdate.tm_mon = tmu_date.tm_mon;
+    if (tmu_date.tm_year > 1900)
+        newdate.tm_year = tmu_date.tm_year - 1900;
+    else
+        newdate.tm_year = tmu_date.tm_year ;
+    newdate.tm_isdst = -1;
+
+    ut.actime = ut.modtime = mktime(&newdate);
+    utime(filename,&ut);
+#endif
+#endif
+}
+
+local int check_file_exists(const char* filename)
+{
+    FILE* ftestexist = FOPEN_FUNC(filename,"rb");
+    if (ftestexist == NULL)
+        return 0;
+    fclose(ftestexist);
+    return 1;
+}
+
+local int makedir(const char *newdir)
+{
+    char *buffer = NULL;
+    char *p = NULL;
+    int len = (int)strlen(newdir);
+
+    if (len <= 0)
+        return 0;
+
+    buffer = (char*)malloc(len+1);
+    if (buffer == NULL)
+    {
+        printf("Error allocating memory\n");
+        return UNZ_INTERNALERROR;
+    }
+
+    strcpy(buffer, newdir);
+
+    if (buffer[len-1] == '/')
+        buffer[len-1] = 0;
+
+    if (MKDIR(buffer) == 0)
+    {
+        free(buffer);
+        return 1;
+    }
+
+    p = buffer + 1;
+    while (1)
+    {
+        char hold;
+        while(*p && *p != '\\' && *p != '/')
+            p++;
+        hold = *p;
+        *p = 0;
+
+        if ((MKDIR(buffer) == -1) && (errno == ENOENT))
+        {
+            printf("couldn't create directory %s (%d)\n", buffer, errno);
+            free(buffer);
+            return 0;
+        }
+
+        if (hold == 0)
+            break;
+
+        *p++ = hold;
+    }
+
+    free(buffer);
+    return 1;
+}
+
+extern int ZEXPORT do_extract_currentfile(unzFile uf, int opt_extract_without_path, int* popt_overwrite, const char *password)
+{
+    unz_file_info64 file_info = {0};
+    FILE* fout = NULL;
+    void* buf = NULL;
+    uInt size_buf = WRITEBUFFERSIZE;
+    int err = UNZ_OK;
+    int errclose = UNZ_OK;
+    int skip = 0;
+    char filename_inzip[256] = {0};
+    char* filename_withoutpath = NULL;
+    const char* write_filename = NULL;
+    char* p = NULL;
+
+    err = unzGetCurrentFileInfo64(uf, &file_info, filename_inzip, sizeof(filename_inzip), NULL, 0, NULL, 0);
+    if (err != UNZ_OK)
+    {
+        printf("error %d with zipfile in unzGetCurrentFileInfo\n",err);
+        return err;
+    }
+
+    p = filename_withoutpath = filename_inzip;
+    while (*p != 0)
+    {
+        if ((*p == '/') || (*p == '\\'))
+            filename_withoutpath = p+1;
+        p++;
+    }
+
+    /* If zip entry is a directory then create it on disk */
+    if (*filename_withoutpath == 0)
+    {
+        if (opt_extract_without_path == 0)
+        {
+            printf("creating directory: %s\n", filename_inzip);
+            MKDIR(filename_inzip);
+        }
+        return err;
+    }
+
+    buf = (void*)malloc(size_buf);
+    if (buf == NULL)
+    {
+        printf("Error allocating memory\n");
+        return UNZ_INTERNALERROR;
+    }
+
+    err = unzOpenCurrentFilePassword(uf, password);
+    if (err != UNZ_OK)
+        printf("error %d with zipfile in unzOpenCurrentFilePassword\n", err);
+
+    if (opt_extract_without_path)
+        write_filename = filename_withoutpath;
+    else
+        write_filename = filename_inzip;
+
+    /* Determine if the file should be overwritten or not and ask the user if needed */
+    if ((err == UNZ_OK) && (*popt_overwrite == 0) && (check_file_exists(write_filename)))
+    {
+        char rep = 0;
+        do
+        {
+            char answer[128];
+            printf("The file %s exists. Overwrite ? [y]es, [n]o, [A]ll: ", write_filename);
+            if (scanf("%1s", answer) != 1)
+                exit(EXIT_FAILURE);
+            rep = answer[0];
+            if ((rep >= 'a') && (rep <= 'z'))
+                rep -= 0x20;
+        }
+        while ((rep != 'Y') && (rep != 'N') && (rep != 'A'));
+
+        if (rep == 'N')
+            skip = 1;
+        if (rep == 'A')
+            *popt_overwrite = 1;
+    }
+
+    /* Create the file on disk so we can unzip to it */
+    if ((skip == 0) && (err == UNZ_OK))
+    {
+        fout = FOPEN_FUNC(write_filename, "wb");
+        /* Some zips don't contain directory alone before file */
+        if ((fout == NULL) && (opt_extract_without_path == 0) &&
+            (filename_withoutpath != (char*)filename_inzip))
+        {
+            char c = *(filename_withoutpath-1);
+            *(filename_withoutpath-1) = 0;
+            makedir(write_filename);
+            *(filename_withoutpath-1) = c;
+            fout = FOPEN_FUNC(write_filename, "wb");
+        }
+        if (fout == NULL)
+            printf("error opening %s\n", write_filename);
+    }
+
+    /* Read from the zip, unzip to buffer, and write to disk */
+    if (fout != NULL)
+    {
+        printf(" extracting: %s\n", write_filename);
+
+        do
+        {
+            err = unzReadCurrentFile(uf, buf, size_buf);
+            if (err < 0)
+            {
+                printf("error %d with zipfile in unzReadCurrentFile\n", err);
+                break;
+            }
+            if (err == 0)
+                break;
+            if (fwrite(buf, err, 1, fout) != 1)
+            {
+                printf("error %d in writing extracted file\n", errno);
+                err = UNZ_ERRNO;
+                break;
+            }
+        }
+        while (err > 0);
+
+        if (fout)
+            fclose(fout);
+
+        /* Set the time of the file that has been unzipped */
+        if (err == 0)
+            change_file_date(write_filename,file_info.dosDate, file_info.tmu_date);
+    }
+
+    errclose = unzCloseCurrentFile(uf);
+    if (errclose != UNZ_OK)
+        printf("error %d with zipfile in unzCloseCurrentFile\n", errclose);
+
+    free(buf);
+    return err;
+}
+
+extern int ZEXPORT do_extract_all(unzFile uf, int opt_extract_without_path, int opt_overwrite, const char *password)
+{
+    int err = unzGoToFirstFile(uf);
+    if (err != UNZ_OK)
+    {
+        printf("error %d with zipfile in unzGoToFirstFile\n", err);
+        return 1;
+    }
+
+    do
+    {
+        err = do_extract_currentfile(uf, opt_extract_without_path, &opt_overwrite, password);
+        if (err != UNZ_OK)
+            break;
+        err = unzGoToNextFile(uf);
+    }
+    while (err == UNZ_OK);
+
+    if (err != UNZ_END_OF_LIST_OF_FILE)
+    {
+        printf("error %d with zipfile in unzGoToNextFile\n", err);
+        return 1;
+    }
+    return 0;
+}
+
+extern int ZEXPORT do_extract_onefile(unzFile uf, const char* filename, int opt_extract_without_path, int opt_overwrite,
+    const char* password)
+{
+    if (unzLocateFile(uf, filename, NULL) != UNZ_OK)
+    {
+        printf("file %s not found in the zipfile\n", filename);
+        return 2;
+    }
+    if (do_extract_currentfile(uf, opt_extract_without_path, &opt_overwrite, password) == UNZ_OK)
+        return 0;
+    return 1;
 }

--- a/unzip.c
+++ b/unzip.c
@@ -2053,6 +2053,11 @@ local int makedir(const char *newdir)
     return 1;
 }
 
+extern int ZEXPORT minizip_get_writebuffersize()
+{
+    return WRITEBUFFERSIZE;
+}
+
 extern int ZEXPORT do_extract_currentfile(unzFile uf, int opt_extract_without_path, int* popt_overwrite, const char *password)
 {
     unz_file_info64 file_info = {0};

--- a/unzip.h
+++ b/unzip.h
@@ -35,6 +35,61 @@ extern "C" {
 
 #define Z_BZIP2ED 12
 
+#ifdef _WIN32
+#  define USEWIN32IOAPI
+#  include "iowin32.h"
+#endif
+
+#if (!defined(_WIN32)) && (!defined(WIN32)) && (!defined(__APPLE__))
+#  ifndef __USE_FILE_OFFSET64
+#    define __USE_FILE_OFFSET64
+#  endif
+#  ifndef __USE_LARGEFILE64
+#    define __USE_LARGEFILE64
+#  endif
+#  ifndef _LARGEFILE64_SOURCE
+#    define _LARGEFILE64_SOURCE
+#  endif
+#  ifndef _FILE_OFFSET_BIT
+#    define _FILE_OFFSET_BIT 64
+#  endif
+#endif
+
+#ifdef __APPLE__
+/* In darwin and perhaps other BSD variants off_t is a 64 bit value, hence no need for specific 64 bit functions */
+#  define FOPEN_FUNC(filename, mode) fopen(filename, mode)
+#  define FTELLO_FUNC(stream) ftello(stream)
+#  define FSEEKO_FUNC(stream, offset, origin) fseeko(stream, offset, origin)
+#else
+#  define FOPEN_FUNC(filename, mode) fopen64(filename, mode)
+#  define FTELLO_FUNC(stream) ftello64(stream)
+#  define FSEEKO_FUNC(stream, offset, origin) fseeko64(stream, offset, origin)
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <errno.h>
+#include <fcntl.h>
+
+#ifdef _WIN32
+#  include <direct.h>
+#  include <io.h>
+#else
+#  include <sys/stat.h>
+#  include <unistd.h>
+#  include <utime.h>
+#endif
+
+#ifdef _WIN32
+#  define MKDIR(d) _mkdir(d)
+#  define CHDIR(d) _chdir(d)
+#else
+#  define MKDIR(d) mkdir(d, 0775)
+#  define CHDIR(d) chdir(d)
+#endif
+
 #if defined(STRICTUNZIP) || defined(STRICTZIPUNZIP)
 /* like the STRICT of WIN32, we define a pointer that cannot be converted
     from (void*) without cast */
@@ -312,6 +367,10 @@ extern int ZEXPORT unzeof OF((unzFile file));
 
 /***************************************************************************/
 
+extern int ZEXPORT do_extract_currentfile(unzFile uf, int opt_extract_without_path, int* popt_overwrite, const char *password);
+extern int ZEXPORT do_extract_all(unzFile uf, int opt_extract_without_path, int opt_overwrite, const char *password);
+extern int ZEXPORT do_extract_onefile(unzFile uf, const char* filename, int opt_extract_without_path, int opt_overwrite,
+                                      const char* password);
 #ifdef __cplusplus
 }
 #endif

--- a/zip.c
+++ b/zip.c
@@ -105,6 +105,9 @@
 #  endif
 #endif
 
+#define WRITEBUFFERSIZE (16384)
+#define MAXFILENAME     (256)
+
 const char zip_copyright[] = " zip 1.01 Copyright 1998-2004 Gilles Vollant - http://www.winimage.com/zLibDll";
 
 typedef struct linkedlist_datablock_internal_s
@@ -2042,5 +2045,124 @@ extern int ZEXPORT zipClose2_64(zipFile file, const char* global_comment, uLong 
 #endif
     TRYFREE(zi);
 
+    return err;
+}
+
+extern uLong ZEXPORT filetime(const char *filename, tm_zip *tmzip, uLong *dostime)
+{
+    int ret = 0;
+#ifdef _WIN32
+    FILETIME ftLocal;
+    HANDLE hFind;
+    WIN32_FIND_DATAA ff32;
+
+    hFind = FindFirstFileA(filename, &ff32);
+    if (hFind != INVALID_HANDLE_VALUE)
+    {
+        FileTimeToLocalFileTime(&(ff32.ftLastWriteTime), &ftLocal);
+        FileTimeToDosDateTime(&ftLocal,((LPWORD)dostime)+1,((LPWORD)dostime)+0);
+        FindClose(hFind);
+        ret = 1;
+    }
+#else
+#if defined unix || defined __APPLE__
+    struct stat s = {0};
+    struct tm* filedate;
+    time_t tm_t = 0;
+
+    if (strcmp(filename,"-") != 0)
+    {
+        char name[MAXFILENAME+1];
+        int len = strlen(filename);
+        if (len > MAXFILENAME)
+            len = MAXFILENAME;
+
+        strncpy(name, filename, MAXFILENAME - 1);
+        name[MAXFILENAME] = 0;
+
+        if (name[len - 1] == '/')
+            name[len - 1] = 0;
+
+        /* not all systems allow stat'ing a file with / appended */
+        if (stat(name,&s) == 0)
+        {
+            tm_t = s.st_mtime;
+            ret = 1;
+        }
+    }
+
+    filedate = localtime(&tm_t);
+
+    tmzip->tm_sec  = filedate->tm_sec;
+    tmzip->tm_min  = filedate->tm_min;
+    tmzip->tm_hour = filedate->tm_hour;
+    tmzip->tm_mday = filedate->tm_mday;
+    tmzip->tm_mon  = filedate->tm_mon ;
+    tmzip->tm_year = filedate->tm_year;
+#endif
+#endif
+    return ret;
+}
+
+extern int ZEXPORT check_file_exists(const char* filename)
+{
+    FILE* ftestexist = FOPEN_FUNC(filename, "rb");
+    if (ftestexist == NULL)
+        return 0;
+    fclose(ftestexist);
+    return 1;
+}
+
+extern int ZEXPORT is_large_file(const char* filename)
+{
+    ZPOS64_T pos = 0;
+    FILE* pFile = FOPEN_FUNC(filename, "rb");
+
+    if (pFile == NULL)
+        return 0;
+
+    FSEEKO_FUNC(pFile, 0, SEEK_END);
+    pos = FTELLO_FUNC(pFile);
+    fclose(pFile);
+
+    printf("File : %s is %lld bytes\n", filename, pos);
+
+    return (pos >= 0xffffffff);
+}
+
+/* Calculate the CRC32 of a file, because to encrypt a file, we need known the CRC32 of the file before */
+extern int ZEXPORT get_file_crc(const char* filenameinzip, void *buf, unsigned long size_buf, unsigned long* result_crc)
+{
+    FILE *fin = NULL;
+    unsigned long calculate_crc = 0;
+    unsigned long size_read = 0;
+    int err = ZIP_OK;
+
+    fin = FOPEN_FUNC(filenameinzip,"rb");
+    if (fin == NULL)
+        err = ZIP_ERRNO;
+    else
+    {
+        do
+        {
+            size_read = (int)fread(buf,1,size_buf,fin);
+
+            if ((size_read < size_buf) && (feof(fin) == 0))
+            {
+                printf("error in reading %s\n",filenameinzip);
+                err = ZIP_ERRNO;
+            }
+
+            if (size_read > 0)
+                calculate_crc = crc32(calculate_crc,buf,size_read);
+        }
+        while ((err == ZIP_OK) && (size_read > 0));
+    }
+
+    if (fin)
+        fclose(fin);
+
+    printf("file %s crc %lx\n", filenameinzip, calculate_crc);
+    *result_crc = calculate_crc;
     return err;
 }

--- a/zip.h
+++ b/zip.h
@@ -196,6 +196,7 @@ extern int ZEXPORT zipClose2_64 OF((zipFile file, const char* global_comment, uL
 
 /***************************************************************************/
 
+
 #ifdef __cplusplus
 }
 #endif

--- a/zip.h
+++ b/zip.h
@@ -33,6 +33,22 @@ extern "C" {
 
 #define Z_BZIP2ED 12
 
+#ifdef _WIN32
+#  define USEWIN32IOAPI
+#  include "iowin32.h"
+#endif
+
+#ifdef __APPLE__
+/* In darwin and perhaps other BSD variants off_t is a 64 bit value, hence no need for specific 64 bit functions */
+#  define FOPEN_FUNC(filename, mode) fopen(filename, mode)
+#  define FTELLO_FUNC(stream) ftello(stream)
+#  define FSEEKO_FUNC(stream, offset, origin) fseeko(stream, offset, origin)
+#else
+#  define FOPEN_FUNC(filename, mode) fopen64(filename, mode)
+#  define FTELLO_FUNC(stream) ftello64(stream)
+#  define FSEEKO_FUNC(stream, offset, origin) fseeko64(stream, offset, origin)
+#endif
+
 #if defined(STRICTZIP) || defined(STRICTZIPUNZIP)
 /* like the STRICT of WIN32, we define a pointer that cannot be converted
     from (void*) without cast */
@@ -196,6 +212,13 @@ extern int ZEXPORT zipClose2_64 OF((zipFile file, const char* global_comment, uL
 
 /***************************************************************************/
 
+extern int ZEXPORT minizip_get_writebuffersize();
+extern int ZEXPORT check_file_exists(const char* filename);
+extern uLong ZEXPORT filetime(const char *filename, tm_zip *tmzip, uLong *dostime);
+extern int ZEXPORT is_large_file(const char* filename);
+
+/* Calculate the CRC32 of a file, because to encrypt a file, we need known the CRC32 of the file before */
+extern int ZEXPORT get_file_crc(const char* filenameinzip, void *buf, unsigned long size_buf, unsigned long* result_crc);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
I found that, by moving some higher-level routines such as check_file_exists and do_extract_all from the minizip.c and miniunz.c executables into the zip.c and unzip.c files within the static library, I was able to significantly reduce the amount of code I had to copy and paste into my own application without having to change the behaviour or interfaces of the minizip library itself.This is the version I'm now using.