### PR TITLE
adding a podspec

### DIFF
--- a/Minizip.podspec
+++ b/Minizip.podspec
@@ -1,0 +1,28 @@
+Pod::Spec.new do |s|
+  s.name     = 'Minizip'
+  s.version  = '1.1.0.2016.04.24'
+  s.license  = 'zlib'
+  s.summary  = 'Minizip contrib in zlib with latest bug fixes that supports PKWARE disk spanning, AES encryption, and IO buffering'
+  s.description = <<-DESC
+Minizip zlib contribution that includes:
+* AES encryption
+* I/O buffering
+* PKWARE disk spanning
+It also has the latest bug fixes that having been found all over the internet including the minizip forum and zlib developer's mailing list.
+DESC
+  s.homepage = 'http://www.winimage.com/zLibDll/minizip.html'
+  s.authors = 'Gilles Vollant', 'Nathan Moinvaziri'
+
+  s.source   = { :git => 'https://github.com/nmoinvaz/minizip.git' }
+  s.libraries = 'z'
+
+  s.subspec 'Core' do |sp|
+    sp.source_files = '{ioapi,ioapi_mem,ioapi_buf,unzip,zip}.{c,h}', 'crypt.h'
+    sp.public_header_files = '{ioapi,unzip,zip}.h'
+  end
+
+  s.subspec 'AES' do |sp|
+    sp.source_files = 'aes/*.{c,h}', '{ioapi,ioapi_mem,ioapi_buf,unzip,zip}.{c,h}', 'crypt.h'
+    sp.public_header_files = '{ioapi,unzip,zip}.h'
+  end
+end

--- a/Minizip.podspec
+++ b/Minizip.podspec
@@ -18,11 +18,10 @@ DESC
 
   s.subspec 'Core' do |sp|
     sp.source_files = '{ioapi,ioapi_mem,ioapi_buf,unzip,zip}.{c,h}', 'crypt.h'
-    sp.public_header_files = '{ioapi,unzip,zip}.h'
   end
 
   s.subspec 'AES' do |sp|
-    sp.source_files = 'aes/*.{c,h}', '{ioapi,ioapi_mem,ioapi_buf,unzip,zip}.{c,h}', 'crypt.h'
-    sp.public_header_files = '{ioapi,unzip,zip}.h'
+    sp.dependency 'Minizip/Core'
+    sp.source_files = 'aes/*.{c,h}'
   end
 end


### PR DESCRIPTION
A podspec inside the repository itself will make it easier for wrappers (like [SSZipArchive](https://github.com/ZipArchive/ZipArchive), [mattconnolly/ZipArchive](https://github.com/mattconnolly/ZipArchive), [dexman/Minizip](https://github.com/dexman/Minizip), ...) to use Minizip as a dependency. It will also help [CocoaPods](https://cocoapods.org/) users to include Minizip in their projects, as they will simply have to write:

    # Minizip with AES
    pod 'Minizip', :git => 'https://github.com/nmoinvaz/minizip.git'

or:

    # Minizip without AES
    pod 'Minizip/Core', :git => 'https://github.com/nmoinvaz/minizip.git'

And if you decide to tag your releases on this repository and push your podspec to trunk, then people will be able to use semantic versioning:

    pod 'nmoinvazMinizip', '~> 1.1'
