### PR TITLE
Fixed opening for read while zip locked by opening to write.

### DIFF
--- a/iowin32.c
+++ b/iowin32.c
@@ -56,13 +56,14 @@ static void win32_translate_open_mode(int mode,
                                       DWORD* lpdwShareMode,
                                       DWORD* lpdwFlagsAndAttributes)
 {
-    *lpdwDesiredAccess = *lpdwShareMode = *lpdwFlagsAndAttributes = *lpdwCreationDisposition = 0;
+    *lpdwDesiredAccess = *lpdwShareMode = *lpdwCreationDisposition = 0;
+    *lpdwFlagsAndAttributes = FILE_ATTRIBUTE_NORMAL;
 
     if ((mode & ZLIB_FILEFUNC_MODE_READWRITEFILTER) == ZLIB_FILEFUNC_MODE_READ)
     {
         *lpdwDesiredAccess = GENERIC_READ;
         *lpdwCreationDisposition = OPEN_EXISTING;
-        *lpdwShareMode = FILE_SHARE_READ;
+        *lpdwShareMode = FILE_SHARE_READ | FILE_SHARE_WRITE;
     }
     else if (mode & ZLIB_FILEFUNC_MODE_EXISTING)
     {


### PR DESCRIPTION
It's possible to read file even if opened to write by the same process.
To enable this feature, I've added FILE_SHARE_WRITE flag.
I've also added flagsAndAttributes initialization by more appropriate
constant 0x80.
