### PR TITLE
Fix error C2664 on MSVC 2015

### DIFF
--- a/ioapi.c
+++ b/ioapi.c
@@ -120,7 +120,7 @@ static voidpf file_build_ioposix(FILE *file, const char *filename)
     ioposix->file = file;
     ioposix->filenameLength = (int)strlen(filename) + 1;
     ioposix->filename = (char*)malloc(ioposix->filenameLength * sizeof(char));
-    strncpy(ioposix->filename, filename, ioposix->filenameLength);
+    strncpy((char*)ioposix->filename, filename, ioposix->filenameLength);
     return (voidpf)ioposix;
 }
 
@@ -173,7 +173,7 @@ static voidpf ZCALLBACK fopendisk64_file_func (voidpf opaque, voidpf stream, uns
         return NULL;
     ioposix = (FILE_IOPOSIX*)stream;
     diskFilename = (char*)malloc(ioposix->filenameLength * sizeof(char));
-    strncpy(diskFilename, ioposix->filename, ioposix->filenameLength);
+    strncpy(diskFilename, (const char*)ioposix->filename, ioposix->filenameLength);
     for (i = ioposix->filenameLength - 1; i >= 0; i -= 1)
     {
         if (diskFilename[i] != '.')
@@ -198,7 +198,7 @@ static voidpf ZCALLBACK fopendisk_file_func (voidpf opaque, voidpf stream, unsig
         return NULL;
     ioposix = (FILE_IOPOSIX*)stream;
     diskFilename = (char*)malloc(ioposix->filenameLength * sizeof(char));
-    strncpy(diskFilename, ioposix->filename, ioposix->filenameLength);
+    strncpy(diskFilename, (const char*)ioposix->filename, ioposix->filenameLength);
     for (i = ioposix->filenameLength - 1; i >= 0; i -= 1)
     {
         if (diskFilename[i] != '.')


### PR DESCRIPTION
I'm compiling minizip in my project by #including its source code inline (namely, `unzip.c` and `ioapi.c`) in MSVC 2015. I'll let the compiler speak for itself:
```
ioapi.c(201): error C2664: 'char *strncpy(char *,const char *,std::size_t)': cannot convert argument 2 from 'void *' to 'const char *'
ioapi.c(201): note: Conversion from 'void*' to pointer to non-'void' requires an explicit cast
```
There are two more in the same vein. This PR is a trivial fix for these errors.