### PR TITLE
fix Dereference of null pointer if flagBase & 1 and password is NULL

### DIFF
--- a/zip.c
+++ b/zip.c
@@ -1054,6 +1054,10 @@ extern int ZEXPORT zipOpenNewFileInZip4_64(zipFile file, const char* filename, c
         zi->ci.method = AES_METHOD;
 #endif
     }
+    else
+    {
+        zi->ci.flag &= ~1;
+    }
 
     if (zi->disk_size > 0)
     {
@@ -1276,7 +1280,7 @@ extern int ZEXPORT zipOpenNewFileInZip4_64(zipFile file, const char* filename, c
 
 #ifndef NOCRYPT
     zi->ci.crypt_header_size = 0;
-    if ((err == Z_OK) && ((zi->ci.flag & 1) != 0))
+    if ((err == Z_OK) && password != NULL)
     {
 #ifdef HAVE_AES
         if (zi->ci.method == AES_METHOD)


### PR DESCRIPTION
Xcode is giving warning for `*passwd` when password is NULL.