### PR TITLE
fix typo error in get_file_date()

### DIFF
--- a/minishared.c
+++ b/minishared.c
@@ -82,7 +82,7 @@ uint32_t get_file_date(const char *path, uint32_t *dos_date)
     }
 
     filedate = localtime(&tm_t);
-    *dosdate = tm_to_dosdate(filedate);
+    *dos_date = tm_to_dosdate(filedate);
 #endif
 #endif
     return ret;


### PR DESCRIPTION
This fix a missing underscore in the "dos_date" variable, preventing the compilation of the library on a unix-like machine.