### PR TITLE
fix Makefile.am

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -36,8 +36,12 @@ pkgconfig_DATA = minizip.pc
 
 EXTRA_PROGRAMS = miniunzip minizip
 
-miniunzip_SOURCES = miniunz.c
+miniunzip_SOURCES = \
+	minishared.c \
+	miniunz.c
 miniunzip_LDADD = libminizip.la
 
-minizip_SOURCES = minizip.c
+minizip_SOURCES = \
+	minizip.c \
+	minishared.c
 minizip_LDADD = libminizip.la -lz


### PR DESCRIPTION
Makefile.am got broken after https://github.com/nmoinvaz/minizip/commit/28ad5bf4fb7ceb1014e1d80c9b64ce52bb329329
This PR fixes it.

Without:
```
miniunz.o:miniunz.c:(.text+0x1e8): undefined reference to `dosdate_to_tm'
miniunz.o:miniunz.c:(.text+0x695): undefined reference to `makedir'
miniunz.o:miniunz.c:(.text+0x6eb): undefined reference to `change_file_date'
miniunz.o:miniunz.c:(.text+0x71a): undefined reference to `check_file_exists'
collect2.exe: error: ld returned 1 exit status
minizip.o:minizip.c:(.text.startup+0x270): undefined reference to `get_file_date'
minizip.o:minizip.c:(.text.startup+0x281): undefined reference to `is_large_file'
minizip.o:minizip.c:(.text.startup+0x4e9): undefined reference to `get_file_crc'
minizip.o:minizip.c:(.text.startup+0x572): undefined reference to `check_file_exists'
minizip.o:minizip.c:(.text.startup+0x5c4): undefined reference to `check_file_exists'
collect2.exe: error: ld returned 1 exit status
```