### PR TITLE
avoid unnecessary cast

### DIFF
--- a/zip.c
+++ b/zip.c
@@ -1232,7 +1232,7 @@ extern int ZEXPORT zipOpenNewFileInZip4_64(zipFile file, const char *filename, c
             uint8_t verify1 = 0;
             uint8_t verify2 = 0;
 
-            zi->ci.pcrc_32_tab = (const unsigned int*)get_crc_table();
+            zi->ci.pcrc_32_tab = get_crc_table();
 
             /*
             Info-ZIP modification to ZipCrypto format:


### PR DESCRIPTION
pcrc_32_tab is `const z_crc_t *` (aka 'const unsigned long *')
get_crc_table is `const z_crc_t FAR *` (aka 'const unsigned long *')

And clang is unhappy with the previous cast:
>/minizip/zip.c:1235:32: Incompatible pointer types assigning to 'const z_crc_t *' (aka 'const unsigned long *') from 'const unsigned int *'