### PR TITLE
Move declarations to avoid unused warnings

### DIFF
--- a/unzip.c
+++ b/unzip.c
@@ -1333,7 +1333,6 @@ extern int ZEXPORT unzReadCurrentFile(unzFile file, voidp buf, uint32_t len)
             uint32_t bytes_not_read = 0;
             uint32_t bytes_read = 0;
             uint32_t total_bytes_read = 0;
-            uint32_t i = 0;
 
             if (s->pfile_in_zip_read->stream.next_in != NULL)
                 bytes_not_read = (uint32_t)(s->pfile_in_zip_read->read_buffer + UNZ_BUFSIZE -
@@ -1384,6 +1383,8 @@ extern int ZEXPORT unzReadCurrentFile(unzFile file, voidp buf, uint32_t len)
 #endif
                 if (s->pcrc_32_tab != NULL)
                 {
+                    uint32_t i = 0;
+
                     for (i = 0; i < total_bytes_read; i++)
                       s->pfile_in_zip_read->read_buffer[i] =
                           zdecode(s->keys, s->pcrc_32_tab, s->pfile_in_zip_read->read_buffer[i]);

--- a/zip.c
+++ b/zip.c
@@ -1332,8 +1332,6 @@ static int zipFlushWriteBuffer(zip64_internal *zi)
     uint32_t total_written = 0;
     uint32_t write = 0;
     uint32_t max_write = 0;
-    uint32_t i = 0;
-    uint8_t t = 0;
     int err = ZIP_OK;
 
     if ((zi->ci.flag & 1) != 0)
@@ -1347,6 +1345,9 @@ static int zipFlushWriteBuffer(zip64_internal *zi)
         else
 #endif
         {
+            uint32_t i = 0;
+            uint8_t t = 0;
+
             for (i = 0; i < zi->ci.pos_in_buffered_data; i++)
                 zi->ci.buffered_data[i] = (uint8_t)zencode(zi->ci.keys, zi->ci.pcrc_32_tab, zi->ci.buffered_data[i], t);
         }


### PR DESCRIPTION
The warnings show up when some #ifdefs are not active.