### PR TITLE
Clear the stat struct properly to avoid compiler warning

### DIFF
--- a/minishared.c
+++ b/minishared.c
@@ -43,9 +43,11 @@ uint32_t get_file_date(const char *path, uint32_t *dos_date)
         ret = 1;
     }
 #else
-    struct stat s = { 0 };
+    struct stat s;
     struct tm *filedate = NULL;
     time_t tm_t = 0;
+
+    memset(&s, 0, sizeof(s));
 
     if (strcmp(path, "-") != 0)
     {


### PR DESCRIPTION
The original code only initializes the first field which causes clang to spit out "missing field 'st_mode' initializer".