### PR TITLE
Add a support for PNaCl platform

### DIFF
--- a/aes/brg_endian.h
+++ b/aes/brg_endian.h
@@ -30,7 +30,8 @@ Issue Date: 20/12/2007
 #elif defined( __FreeBSD__ ) || defined( __OpenBSD__ ) || defined( __NetBSD__ )
 #  include <sys/endian.h>
 #elif defined( BSD ) && ( BSD >= 199103 ) || defined( __APPLE__ ) || \
-      defined( __CYGWIN32__ ) || defined( __DJGPP__ ) || defined( __osf__ )
+      defined( __CYGWIN32__ ) || defined( __DJGPP__ ) || defined( __osf__ ) || \
+      defined(__pnacl__)
 #  include <machine/endian.h>
 #elif defined( __linux__ ) || defined( __GNUC__ ) || defined( __GNU_LIBRARY__ )
 #  if !defined( __MINGW32__ ) && !defined( _AIX )

--- a/aes/fileenc.c
+++ b/aes/fileenc.c
@@ -36,7 +36,7 @@
 
 */
 
-#include <memory.h>
+#include <string.h>
 
 #include "fileenc.h"
 

--- a/aes/hmac.h
+++ b/aes/hmac.h
@@ -24,7 +24,7 @@ This is an implementation of HMAC, the FIPS standard keyed hash function
 #define _HMAC2_H
 
 #include <stdlib.h>
-#include <memory.h>
+#include <string.h>
 
 #if defined(__cplusplus)
 extern "C"

--- a/aes/prng.c
+++ b/aes/prng.c
@@ -38,7 +38,7 @@
  its location in memory.
 */
 
-#include <memory.h>
+#include <string.h>
 #include "prng.h"
 
 #if defined(__cplusplus)

--- a/aes/pwd2key.c
+++ b/aes/pwd2key.c
@@ -21,7 +21,7 @@ This is an implementation of RFC2898, which specifies key derivation from
 a password and a salt value.
 */
 
-#include <memory.h>
+#include <string.h>
 #include "hmac.h"
 
 #if defined(__cplusplus)


### PR DESCRIPTION
This PR adds a support for PNaCl platform. Because PNaCl does not contain 
memory.h I changed it to string.h. Is this alright or should I rather use 
the preprocessor to determine which library we should include depending on a 
target platform?
