### PR TITLE
fix Unknown type name 'z_crc_t'

### DIFF
--- a/crypt.h
+++ b/crypt.h
@@ -16,6 +16,10 @@
 #ifndef _MINICRYPT_H
 #define _MINICRYPT_H
 
+#if ZLIB_VERNUM < 0x1270
+typedef unsigned long z_crc_t;
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
The issue is affecting users with [zlib 1.2.5](https://opensource.apple.com/source/zlib/zlib-61.20.1/) (available on Xcode 7.x), as it doesn't define z_crc_t yet.

This workaround is not needed anymore with [zlib 1.2.7](https://sourceforge.net/p/miranda/svn/14263/tree/trunk/miranda/plugins/zlib/) (1.2.8 is available on Xcode 8.3) as it defines z_crc_t in zconf.h.
