### PR TITLE
fix miniunz files date for non-WIN32 and adding helper dosdate_to_time_t

### DIFF
--- a/minishared.c
+++ b/minishared.c
@@ -99,7 +99,8 @@ void change_file_date(const char *path, uint32_t dos_date)
 #endif
 }
 
-int dosdate_to_tm(uint64_t dos_date, struct tm *ptm)
+// convertion without validation
+void dosdate_to_raw_tm(uint64_t dos_date, struct tm *ptm)
 {
     uint64_t date = (uint64_t)(dos_date >> 16);
 
@@ -110,19 +111,28 @@ int dosdate_to_tm(uint64_t dos_date, struct tm *ptm)
     ptm->tm_min = (uint16_t)((dos_date & 0x7E0) / 0x20);
     ptm->tm_sec = (uint16_t)(2 * (dos_date & 0x1f));
     ptm->tm_isdst = -1;
-    
+}
+
+int invalid_date(const struct tm *ptm)
+{
 #define datevalue_in_range(min, max, value) ((min) <= (value) && (value) <= (max))
-    if (!datevalue_in_range(0, 11, ptm->tm_mon) ||
-        !datevalue_in_range(1, 31, ptm->tm_mday) ||
-        !datevalue_in_range(0, 23, ptm->tm_hour) ||
-        !datevalue_in_range(0, 59, ptm->tm_min) ||
-        !datevalue_in_range(0, 59, ptm->tm_sec))
-    {
-        /* Invalid date stored, so don't return it. */
+    return (!datevalue_in_range(0, 11, ptm->tm_mon) ||
+            !datevalue_in_range(1, 31, ptm->tm_mday) ||
+            !datevalue_in_range(0, 23, ptm->tm_hour) ||
+            !datevalue_in_range(0, 59, ptm->tm_min) ||
+            !datevalue_in_range(0, 59, ptm->tm_sec));
+#undef datevalue_in_range
+}
+
+int dosdate_to_tm(uint64_t dos_date, struct tm *ptm)
+{
+    dosdate_to_raw_tm(dos_date, ptm);
+    
+    if (invalid_date(ptm)) {
+        // Invalid date stored, so don't return it.
         memset(ptm, 0, sizeof(struct tm));
         return -1;
     }
-#undef datevalue_in_range
     return 0;
 }
 
@@ -139,11 +149,7 @@ uint32_t tm_to_dosdate(const struct tm *ptm)
     Due to the date format limitations, only years between 1980 and 2107 can be stored.
     */
     if (!(datevalue_in_range(1980, 2107, ptm->tm_year) || datevalue_in_range(0, 207, ptm->tm_year)) ||
-        !datevalue_in_range(0, 11, ptm->tm_mon) ||
-        !datevalue_in_range(1, 31, ptm->tm_mday) ||
-        !datevalue_in_range(0, 23, ptm->tm_hour) ||
-        !datevalue_in_range(0, 59, ptm->tm_min) ||
-        !datevalue_in_range(0, 59, ptm->tm_sec))
+        invalid_date(ptm))
     {
         return 0;
     }
@@ -159,6 +165,15 @@ uint32_t tm_to_dosdate(const struct tm *ptm)
 
     return (uint32_t)(((ptm->tm_mday) + (32 * (ptm->tm_mon + 1)) + (512 * year)) << 16) |
         ((ptm->tm_sec / 2) + (32 * ptm->tm_min) + (2048 * (uint32_t)ptm->tm_hour));
+}
+
+time_t dosdate_to_time_t(uint64_t dos_date)
+{
+    struct tm ptm;
+    dosdate_to_raw_tm(dos_date, &ptm);
+    // standard is year 1900 indexed struct tm, but dosdate_to_raw_tm returns a year 0 indexed struct tm
+    ptm.tm_year %= 1900;
+    return mktime(&ptm);
 }
 
 int makedir(const char *newdir)

--- a/minishared.c
+++ b/minishared.c
@@ -90,11 +90,7 @@ void change_file_date(const char *path, uint32_t dos_date)
     }
 #else
     struct utimbuf ut;
-    struct tm newdate;
-
-    dosdate_to_tm(dos_date, &newdate);
-
-    ut.actime = ut.modtime = mktime(&newdate);
+    ut.actime = ut.modtime = dosdate_to_time_t(dos_date);
     utime(path, &ut);
 #endif
 }

--- a/minishared.h
+++ b/minishared.h
@@ -27,6 +27,9 @@ int dosdate_to_tm(uint64_t dos_date, struct tm *ptm);
 /* Convert struct tm to dos date/time format */
 uint32_t tm_to_dosdate(const struct tm *ptm);
 
+/* Convert dos date/time format to time_t */
+time_t dosdate_to_time_t(uint64_t dos_date);
+
 /* Create a directory and all subdirectories */
 int makedir(const char *newdir);
 


### PR DESCRIPTION
In [minishared L137](https://github.com/nmoinvaz/minizip/blob/master/minishared.c#L137) we got this comment:
> (assumed to be between 1980 and 2107, typical output of old software that does 'year-1900' to get a double digit year)

Well, the 'year-1900' is not just for old software, it's because it's defined as a standard in ISO/IEC 9899: https://www.cs.helsinki.fi/group/boi2016/doc/cppreference/reference/en.cppreference.com/w/c/chrono/tm.html.

So when we're adding `+ 1980` on  [minishared L108](https://github.com/nmoinvaz/minizip/blob/master/minishared.c#L108), we're breaking a standard. We should instead be adding `+ 80` only (+ 1980 - 1900). Well, it's a bit late to fix it, so instead I'd like to introduce a helper to convert both a _standard_ `tm` and a _minizip_ `tm` to a `time_t` using `mktime`. **In fact, `mktime` only works correctly with standard `tm`**, so we need to subtract 1900 when dealing with a _minizip_ `tm`, and to do so I'm using `% 1900`.

Also adding a bit of refactoring because `mkdir` does not require to validate the ranges of `struct tm` components.