### PR TITLE
allowing AES to be optional at runtime

### DIFF
--- a/minizip.c
+++ b/minizip.c
@@ -50,16 +50,17 @@ void minizip_banner()
 
 void minizip_help()
 {
-    printf("Usage : minizip [-o] [-a] [-0 to -9] [-p password] [-j] file.zip [files_to_add]\n\n" \
+    printf("Usage : minizip [-o] [-a] [-0 to -9] [-N] [-p password] [-j] file.zip [files_to_add]\n\n" \
            "  -o  Overwrite existing file.zip\n" \
            "  -a  Append to existing file.zip\n" \
            "  -0  Store only\n" \
            "  -1  Compress faster\n" \
-           "  -9  Compress better\n\n" \
+           "  -9  Compress better\n" \
+           "  -N  No AES\n\n" \
            "  -j  exclude path. store only the file name.\n\n");
 }
 
-int minizip_addfile(zipFile zf, const char *path, const char *filenameinzip, int level, const char *password)
+int minizip_addfile(zipFile zf, const char *path, const char *filenameinzip, int level, const char *password, int no_aes)
 {
     zip_fileinfo zi = { 0 };
     FILE *fin = NULL;
@@ -75,11 +76,19 @@ int minizip_addfile(zipFile zf, const char *path, const char *filenameinzip, int
     zip64 = is_large_file(path);
 
     /* Add to zip file */
-    err = zipOpenNewFileInZip3_64(zf, filenameinzip, &zi,
-        NULL, 0, NULL, 0, NULL /* comment*/,
-        (level != 0) ? Z_DEFLATED : 0, level, 0,
-        -MAX_WBITS, DEF_MEM_LEVEL, Z_DEFAULT_STRATEGY,
-        password, 0, zip64);
+    uint16_t method = (level != 0) ? Z_DEFLATED : 0;
+    if (no_aes)
+        err = zipOpenNewFileInZip5_64(zf, filenameinzip, &zi,
+                                      NULL, 0, NULL, 0, NULL /* comment*/,
+                                      method, method, level, 0,
+                                      -MAX_WBITS, DEF_MEM_LEVEL, Z_DEFAULT_STRATEGY,
+                                      password, 0, 0, zip64);
+    else
+        err = zipOpenNewFileInZip3_64(zf, filenameinzip, &zi,
+                                      NULL, 0, NULL, 0, NULL /* comment*/,
+                                      method, level, 0,
+                                      -MAX_WBITS, DEF_MEM_LEVEL, Z_DEFAULT_STRATEGY,
+                                      password, 0, zip64);
 
     if (err != ZIP_OK)
     {
@@ -149,6 +158,7 @@ int main(int argc, char *argv[])
     int opt_overwrite = APPEND_STATUS_CREATE;
     int opt_compress_level = Z_DEFAULT_COMPRESSION;
     int opt_exclude_path = 0;
+    int opt_no_aes = 0;
 
     minizip_banner();
     if (argc == 1)
@@ -173,6 +183,8 @@ int main(int argc, char *argv[])
                     opt_overwrite = APPEND_STATUS_ADDINZIP;
                 if ((c >= '0') && (c <= '9'))
                     opt_compress_level = (c - '0');
+                if (c == 'N')
+                    opt_no_aes = 1;
                 if ((c == 'j') || (c == 'J'))
                     opt_exclude_path = 1;
 
@@ -285,7 +297,7 @@ int main(int argc, char *argv[])
                 filenameinzip = lastslash + 1; /* base filename follows last slash. */
         }
 
-        err = minizip_addfile(zf, filename, filenameinzip, opt_compress_level, password);
+        err = minizip_addfile(zf, filename, filenameinzip, opt_compress_level, password, opt_no_aes);
     }
 
     errclose = zipClose(zf, NULL);

--- a/minizip.c
+++ b/minizip.c
@@ -76,19 +76,21 @@ int minizip_addfile(zipFile zf, const char *path, const char *filenameinzip, int
     zip64 = is_large_file(path);
 
     /* Add to zip file */
-    uint16_t method = (level != 0) ? Z_DEFLATED : 0;
+    uint16_t compression_method = (level != 0) ? Z_DEFLATED : 0;
+    uint16_t method;
     if (no_aes)
-        err = zipOpenNewFileInZip5_64(zf, filenameinzip, &zi,
-                                      NULL, 0, NULL, 0, NULL /* comment*/,
-                                      method, method, level, 0,
-                                      -MAX_WBITS, DEF_MEM_LEVEL, Z_DEFAULT_STRATEGY,
-                                      password, 0, 0, zip64);
+        method = compression_method;
     else
-        err = zipOpenNewFileInZip3_64(zf, filenameinzip, &zi,
-                                      NULL, 0, NULL, 0, NULL /* comment*/,
-                                      method, level, 0,
-                                      -MAX_WBITS, DEF_MEM_LEVEL, Z_DEFAULT_STRATEGY,
-                                      password, 0, zip64);
+#ifdef HAVE_AES
+        method = AES_METHOD;
+#else
+        method = compression_method;
+#endif
+    err = zipOpenNewFileInZip5_64(zf, filenameinzip, &zi,
+                                  NULL, 0, NULL, 0, NULL /* comment*/,
+                                  method, compression_method, level, 0,
+                                  -MAX_WBITS, DEF_MEM_LEVEL, Z_DEFAULT_STRATEGY,
+                                  password, 0, 0, zip64);
 
     if (err != ZIP_OK)
     {

--- a/zip.h
+++ b/zip.h
@@ -170,6 +170,12 @@ extern int ZEXPORT zipOpenNewFileInZip4_64(zipFile file, const char *filename, c
     int strategy, const char *password, ZIP_UNUSED uint32_t crc_for_crypting, uint16_t version_madeby, uint16_t flag_base, int zip64);
 /* Same as zipOpenNewFileInZip4 with zip64 support */
 
+extern int ZEXPORT zipOpenNewFileInZip5_64(zipFile file, const char *filename, const zip_fileinfo *zipfi,
+    const void *extrafield_local, uint16_t size_extrafield_local, const void *extrafield_global,
+    uint16_t size_extrafield_global, const char *comment, uint16_t method, uint16_t compression_method, int level, int raw, int windowBits, int memLevel,
+    int strategy, const char *password, uint16_t version_madeby, uint16_t flag_base, int zip64);
+/* Same as zipOpenNewFileInZip4_64 with compression_method support */
+
 extern int ZEXPORT zipWriteInFileInZip(zipFile file, const void *buf, uint32_t len);
 /* Write data in the zipfile */
 

--- a/zip.h
+++ b/zip.h
@@ -57,6 +57,12 @@ typedef voidp zipFile;
 #  define ZIP_UNUSED
 #endif
 
+#ifdef __GNUC__
+#  define ZIP_DEPRECATED __attribute__((__deprecated__))
+#else
+#  define ZIP_DEPRECATED
+#endif
+
 #ifndef DEF_MEM_LEVEL
 #  if MAX_MEM_LEVEL >= 8
 #    define DEF_MEM_LEVEL 8
@@ -146,7 +152,8 @@ extern int ZEXPORT zipOpenNewFileInZip2_64(zipFile file, const char *filename, c
 extern int ZEXPORT zipOpenNewFileInZip3(zipFile file, const char *filename, const zip_fileinfo *zipfi,
     const void *extrafield_local, uint16_t size_extrafield_local, const void *extrafield_global,
     uint16_t size_extrafield_global, const char *comment, uint16_t method, int level, int raw, int windowBits, int memLevel,
-    int strategy, const char *password, ZIP_UNUSED uint32_t crc_for_crypting);
+    int strategy, const char *password, ZIP_UNUSED uint32_t crc_for_crypting)
+    ZIP_DEPRECATED;
 /* Same as zipOpenNewFileInZip2, except
     windowBits, memLevel, strategy : see parameter strategy in deflateInit2
     password : crypting password (NULL for no crypting)
@@ -155,25 +162,28 @@ extern int ZEXPORT zipOpenNewFileInZip3(zipFile file, const char *filename, cons
 extern int ZEXPORT zipOpenNewFileInZip3_64(zipFile file, const char *filename, const zip_fileinfo *zipfi,
     const void *extrafield_local, uint16_t size_extrafield_local, const void *extrafield_global,
     uint16_t size_extrafield_global, const char *comment, uint16_t method, int level, int raw, int windowBits, int memLevel,
-    int strategy, const char *password, ZIP_UNUSED uint32_t crc_for_crypting, int zip64);
+    int strategy, const char *password, ZIP_UNUSED uint32_t crc_for_crypting, int zip64)
+    ZIP_DEPRECATED;
 /* Same as zipOpenNewFileInZip3 with zip64 support */
 
 extern int ZEXPORT zipOpenNewFileInZip4(zipFile file, const char *filename, const zip_fileinfo *zipfi,
     const void *extrafield_local, uint16_t size_extrafield_local, const void *extrafield_global,
     uint16_t size_extrafield_global, const char *comment, uint16_t method, int level, int raw, int windowBits, int memLevel,
-    int strategy, const char *password, ZIP_UNUSED uint32_t crc_for_crypting, uint16_t version_madeby, uint16_t flag_base);
+    int strategy, const char *password, ZIP_UNUSED uint32_t crc_for_crypting, uint16_t version_madeby, uint16_t flag_base)
+    ZIP_DEPRECATED;
 /* Same as zipOpenNewFileInZip3 except versionMadeBy & flag fields */
 
 extern int ZEXPORT zipOpenNewFileInZip4_64(zipFile file, const char *filename, const zip_fileinfo *zipfi,
     const void *extrafield_local, uint16_t size_extrafield_local, const void *extrafield_global,
     uint16_t size_extrafield_global, const char *comment, uint16_t method, int level, int raw, int windowBits, int memLevel,
-    int strategy, const char *password, ZIP_UNUSED uint32_t crc_for_crypting, uint16_t version_madeby, uint16_t flag_base, int zip64);
+    int strategy, const char *password, ZIP_UNUSED uint32_t crc_for_crypting, uint16_t version_madeby, uint16_t flag_base, int zip64)
+    ZIP_DEPRECATED;
 /* Same as zipOpenNewFileInZip4 with zip64 support */
 
 extern int ZEXPORT zipOpenNewFileInZip5_64(zipFile file, const char *filename, const zip_fileinfo *zipfi,
     const void *extrafield_local, uint16_t size_extrafield_local, const void *extrafield_global,
-    uint16_t size_extrafield_global, const char *comment, uint16_t method, uint16_t compression_method, int level, int raw, int windowBits, int memLevel,
-    int strategy, const char *password, uint16_t version_madeby, uint16_t flag_base, int zip64);
+    uint16_t size_extrafield_global, const char *comment, uint16_t method, uint16_t compression_method, int level, int raw,
+    int windowBits, int memLevel, int strategy, const char *password, uint16_t version_madeby, uint16_t flag_base, int zip64);
 /* Same as zipOpenNewFileInZip4_64 with compression_method support */
 
 extern int ZEXPORT zipWriteInFileInZip(zipFile file, const void *buf, uint32_t len);


### PR DESCRIPTION
When we build minizip with AES support, then [line 981 of zip.c](https://github.com/nmoinvaz/minizip/blob/master/zip.c#L981) is forcing AES encryption.

To give the choice at runtime, I made `zipOpenNewFileInZip5_64` with distinct parameters `method` and `compression_method`. This way, existing `zipOpenNewFileInZip4_64` behavior is unaffected.