### PR TITLE
Define GCC pragmas only for GCC compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,10 @@ if(UNIX)
   add_definitions(-D_FILE_OFFSET_BIT=64)
 endif()
 
+if (CMAKE_C_COMPILER MATCHES ".*clang")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -msse3 -msse4.1 -maes")
+endif ()
+
 # create minizip library
 add_library(minizip ${MINIZIP_SRC} ${MINIZIP_PUBLIC_HEADERS})
 target_link_libraries(minizip ZLIB::ZLIB)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,9 +53,9 @@ if(UNIX)
   add_definitions(-D_FILE_OFFSET_BIT=64)
 endif()
 
-if (CMAKE_C_COMPILER MATCHES ".*clang")
+if(CMAKE_C_COMPILER MATCHES ".*clang")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -msse3 -msse4.1 -maes")
-endif ()
+endif()
 
 # create minizip library
 add_library(minizip ${MINIZIP_SRC} ${MINIZIP_PUBLIC_HEADERS})

--- a/aes/aes_ni.c
+++ b/aes/aes_ni.c
@@ -42,9 +42,13 @@ INLINE int has_aes_ni(void)
 #elif defined( __GNUC__ )
 
 #include <cpuid.h>
+
+#if !defined(__clang__)
 #pragma GCC target ("ssse3")
 #pragma GCC target ("sse4.1")
 #pragma GCC target ("aes")
+#endif
+
 #include <x86intrin.h>
 #define INLINE  static __inline
 


### PR DESCRIPTION
When using clang with -Werror and -Wunknown-pragmas flags, it will not compile successfully because GCC pragmas are not present in clang. This PR limits GCC pragmas to GCC compiler.