### PR TITLE
Add support for non-ASCII characters in paths on Windows

### DIFF
--- a/ioapi.c
+++ b/ioapi.c
@@ -27,6 +27,10 @@
 #  define snprintf _snprintf
 #endif
 
+#if defined(WINDOWS_SUPPORT_UNICODE_PATH)
+#include <Windows.h>
+#endif
+
 voidpf call_zopen64(const zlib_filefunc64_32_def *pfilefunc, const void *filename, int mode)
 {
     if (pfilefunc->zfile_func64.zopen64_file != NULL)
@@ -141,7 +145,17 @@ static voidpf ZCALLBACK fopen64_file_func(voidpf opaque, const void *filename, i
 
     if ((filename != NULL) && (mode_fopen != NULL))
     {
-        file = fopen64((const char*)filename, mode_fopen);
+#if defined(WINDOWS_SUPPORT_UNICODE_PATH)
+		int pathLength = MultiByteToWideChar(CP_UTF8, 0, filename, -1, NULL, 0);
+		wchar_t* newName = (wchar_t*)calloc(pathLength, sizeof(wchar_t));
+		wchar_t newMode[16];
+		MultiByteToWideChar(CP_UTF8, 0, filename, -1, newName, pathLength);
+		mbstowcs(newMode, (const char*)mode_fopen, 16);
+        file = fopen64((const wchar_t*)newName, newMode);
+		free(newName);
+#else
+		file = fopen64((const char*)filename, mode_fopen);
+#endif
         return file_build_ioposix(file, (const char*)filename);
     }
     return file;

--- a/ioapi.h
+++ b/ioapi.h
@@ -33,7 +33,12 @@
 #    define fseeko64 fseeko
 #  endif
 #  ifdef _MSC_VER
-#    define fopen64 fopen
+#    define WINDOWS_SUPPORT_UNICODE_PATH // If defined, paths containing unicode are supported
+#    if defined(WINDOWS_SUPPORT_UNICODE_PATH)
+#      define fopen64 _wfopen
+#    else
+#      define fopen64 fopen
+#    endif
 #    if (_MSC_VER >= 1400) && (!(defined(NO_MSCVER_FILE64_FUNC)))
 #      define ftello64 _ftelli64
 #      define fseeko64 _fseeki64

--- a/minishared.c
+++ b/minishared.c
@@ -220,9 +220,24 @@ int makedir(const char *newdir)
     return 1;
 }
 
+FILE* get_file_handle(const char *path)
+{
+#if defined(WINDOWS_SUPPORT_UNICODE_PATH)
+	int pathLength = MultiByteToWideChar(CP_UTF8, 0, path, -1, NULL, 0);
+	wchar_t* newName = (wchar_t*)calloc(pathLength, sizeof(wchar_t));
+	MultiByteToWideChar(CP_UTF8, 0, path, -1, newName, _ARRAYSIZE(newName));
+	FILE* handle = fopen64((const wchar_t*)newName, L"rb");
+	free(newName);
+#else
+	FILE* handle = fopen64(path, "rb");
+#endif
+	
+    return handle;
+}
+
 int check_file_exists(const char *path)
 {
-    FILE* handle = fopen64(path, "rb");
+	FILE* handle = get_file_handle(path);
     if (handle == NULL)
         return 0;
     fclose(handle);
@@ -232,8 +247,8 @@ int check_file_exists(const char *path)
 int is_large_file(const char *path)
 {
     uint64_t pos = 0;
-    FILE* handle = fopen64(path, "rb");
-
+	
+	FILE* handle = get_file_handle(path);
     if (handle == NULL)
         return 0;
 

--- a/minishared.h
+++ b/minishared.h
@@ -33,6 +33,9 @@ uint32_t tm_to_dosdate(const struct tm *ptm);
 /* Create a directory and all subdirectories */
 int makedir(const char *newdir);
 
+/* Get the file handle */
+FILE* get_file_handle(const char *path);
+
 /* Check to see if a file exists */
 int check_file_exists(const char *path);
 


### PR DESCRIPTION
On Windows, paths containing non ASCII characters were not supported. The reason is that fopen on Windows only supports ASCII characters in paths.

This change adds a define WINDOWS_SUPPORT_UNICODE_PATH which uses _wfopen instead of fopen64 on Windows. Tested on Windows 10.