### PR TITLE
Fix unused parameter warnings generated by -Wunused-parameter

### DIFF
--- a/ioapi.c
+++ b/ioapi.c
@@ -81,7 +81,7 @@ void fill_zlib_filefunc64_32_def_from_filefunc32(zlib_filefunc64_32_def *p_filef
     p_filefunc64_32->ztell32_file = p_filefunc32->ztell_file;
 }
 
-static voidpf   ZCALLBACK fopen_file_func(voidpf opaque, const char *filename, int mode);
+static voidpf   ZCALLBACK fopen_file_func(ZIP_UNUSED voidpf opaque, const char *filename, int mode);
 static uint32_t ZCALLBACK fread_file_func(voidpf opaque, voidpf stream, void* buf, uint32_t size);
 static uint32_t ZCALLBACK fwrite_file_func(voidpf opaque, voidpf stream, const void *buf, uint32_t size);
 static uint64_t ZCALLBACK ftell64_file_func(voidpf opaque, voidpf stream);
@@ -109,7 +109,7 @@ static voidpf file_build_ioposix(FILE *file, const char *filename)
     return (voidpf)ioposix;
 }
 
-static voidpf ZCALLBACK fopen_file_func(voidpf opaque, const char *filename, int mode)
+static voidpf ZCALLBACK fopen_file_func(ZIP_UNUSED voidpf opaque, const char *filename, int mode)
 {
     FILE* file = NULL;
     const char *mode_fopen = NULL;
@@ -128,7 +128,7 @@ static voidpf ZCALLBACK fopen_file_func(voidpf opaque, const char *filename, int
     return file;
 }
 
-static voidpf ZCALLBACK fopen64_file_func(voidpf opaque, const void *filename, int mode)
+static voidpf ZCALLBACK fopen64_file_func(ZIP_UNUSED voidpf opaque, const void *filename, int mode)
 {
     FILE* file = NULL;
     const char *mode_fopen = NULL;
@@ -197,7 +197,7 @@ static voidpf ZCALLBACK fopendisk_file_func(voidpf opaque, voidpf stream, uint32
     return ret;
 }
 
-static uint32_t ZCALLBACK fread_file_func(voidpf opaque, voidpf stream, void* buf, uint32_t size)
+static uint32_t ZCALLBACK fread_file_func(ZIP_UNUSED voidpf opaque, voidpf stream, void* buf, uint32_t size)
 {
     FILE_IOPOSIX *ioposix = NULL;
     uint32_t read = (uint32_t)-1;
@@ -208,7 +208,7 @@ static uint32_t ZCALLBACK fread_file_func(voidpf opaque, voidpf stream, void* bu
     return read;
 }
 
-static uint32_t ZCALLBACK fwrite_file_func(voidpf opaque, voidpf stream, const void *buf, uint32_t size)
+static uint32_t ZCALLBACK fwrite_file_func(ZIP_UNUSED voidpf opaque, voidpf stream, const void *buf, uint32_t size)
 {
     FILE_IOPOSIX *ioposix = NULL;
     uint32_t written = (uint32_t)-1;
@@ -219,7 +219,7 @@ static uint32_t ZCALLBACK fwrite_file_func(voidpf opaque, voidpf stream, const v
     return written;
 }
 
-static long ZCALLBACK ftell_file_func(voidpf opaque, voidpf stream)
+static long ZCALLBACK ftell_file_func(ZIP_UNUSED voidpf opaque, voidpf stream)
 {
     FILE_IOPOSIX *ioposix = NULL;
     long ret = -1;
@@ -230,7 +230,7 @@ static long ZCALLBACK ftell_file_func(voidpf opaque, voidpf stream)
     return ret;
 }
 
-static uint64_t ZCALLBACK ftell64_file_func(voidpf opaque, voidpf stream)
+static uint64_t ZCALLBACK ftell64_file_func(ZIP_UNUSED voidpf opaque, voidpf stream)
 {
     FILE_IOPOSIX *ioposix = NULL;
     uint64_t ret = (uint64_t)-1;
@@ -241,7 +241,7 @@ static uint64_t ZCALLBACK ftell64_file_func(voidpf opaque, voidpf stream)
     return ret;
 }
 
-static long ZCALLBACK fseek_file_func(voidpf opaque, voidpf stream, uint32_t offset, int origin)
+static long ZCALLBACK fseek_file_func(ZIP_UNUSED voidpf opaque, voidpf stream, uint32_t offset, int origin)
 {
     FILE_IOPOSIX *ioposix = NULL;
     int fseek_origin = 0;
@@ -270,7 +270,7 @@ static long ZCALLBACK fseek_file_func(voidpf opaque, voidpf stream, uint32_t off
     return ret;
 }
 
-static long ZCALLBACK fseek64_file_func(voidpf opaque, voidpf stream, uint64_t offset, int origin)
+static long ZCALLBACK fseek64_file_func(ZIP_UNUSED voidpf opaque, voidpf stream, uint64_t offset, int origin)
 {
     FILE_IOPOSIX *ioposix = NULL;
     int fseek_origin = 0;
@@ -301,7 +301,7 @@ static long ZCALLBACK fseek64_file_func(voidpf opaque, voidpf stream, uint64_t o
     return ret;
 }
 
-static int ZCALLBACK fclose_file_func(voidpf opaque, voidpf stream)
+static int ZCALLBACK fclose_file_func(ZIP_UNUSED voidpf opaque, voidpf stream)
 {
     FILE_IOPOSIX *ioposix = NULL;
     int ret = -1;
@@ -315,7 +315,7 @@ static int ZCALLBACK fclose_file_func(voidpf opaque, voidpf stream)
     return ret;
 }
 
-static int ZCALLBACK ferror_file_func(voidpf opaque, voidpf stream)
+static int ZCALLBACK ferror_file_func(ZIP_UNUSED voidpf opaque, voidpf stream)
 {
     FILE_IOPOSIX *ioposix = NULL;
     int ret = -1;

--- a/ioapi.h
+++ b/ioapi.h
@@ -22,6 +22,12 @@
 
 #include "zlib.h"
 
+#ifdef __GNUC__
+#  define ZIP_UNUSED __attribute__((__unused__))
+#else
+#  define ZIP_UNUSED
+#endif
+
 #if defined(USE_FILE32API)
 #  define fopen64 fopen
 #  define ftello64 ftell

--- a/ioapi_buf.c
+++ b/ioapi_buf.c
@@ -75,7 +75,7 @@ typedef struct ourstream_s {
 #  define print_buf(o,s,f,...)
 #endif
 
-void print_buf_internal(voidpf opaque, voidpf stream, char *format, ...)
+void print_buf_internal(ZIP_UNUSED voidpf opaque, voidpf stream, char *format, ...)
 {
     ourstream_t *streamio = (ourstream_t *)stream;
     va_list arglist;
@@ -85,7 +85,7 @@ void print_buf_internal(voidpf opaque, voidpf stream, char *format, ...)
     va_end(arglist);
 }
 
-voidpf fopen_buf_internal_func(voidpf opaque, voidpf stream, uint32_t number_disk, int mode)
+voidpf fopen_buf_internal_func(ZIP_UNUSED voidpf opaque, voidpf stream, ZIP_UNUSED uint32_t number_disk, ZIP_UNUSED int mode)
 {
     ourstream_t *streamio = NULL;
     if (stream == NULL)
@@ -280,7 +280,7 @@ uint32_t ZCALLBACK fwrite_buf_func(voidpf opaque, voidpf stream, const void *buf
     return size - bytes_left_to_write;
 }
 
-uint64_t ftell_buf_internal_func(voidpf opaque, voidpf stream, uint64_t position)
+uint64_t ftell_buf_internal_func(ZIP_UNUSED voidpf opaque, voidpf stream, uint64_t position)
 {
     ourstream_t *streamio = (ourstream_t *)stream;
     streamio->position = position;

--- a/ioapi_mem.c
+++ b/ioapi_mem.c
@@ -35,7 +35,7 @@
 #  define IOMEM_BUFFERSIZE (UINT16_MAX)
 #endif
 
-voidpf ZCALLBACK fopen_mem_func(voidpf opaque, const char *filename, int mode)
+voidpf ZCALLBACK fopen_mem_func(voidpf opaque, ZIP_UNUSED const char *filename, int mode)
 {
     ourmemory_t *mem = (ourmemory_t *)opaque;
     if (mem == NULL)
@@ -59,13 +59,13 @@ voidpf ZCALLBACK fopen_mem_func(voidpf opaque, const char *filename, int mode)
     return mem;
 }
 
-voidpf ZCALLBACK fopendisk_mem_func(voidpf opaque, voidpf stream, uint32_t number_disk, int mode)
+voidpf ZCALLBACK fopendisk_mem_func(ZIP_UNUSED voidpf opaque, ZIP_UNUSED voidpf stream, ZIP_UNUSED uint32_t number_disk, ZIP_UNUSED int mode)
 {
     /* Not used */
     return NULL;
 }
 
-uint32_t ZCALLBACK fread_mem_func(voidpf opaque, voidpf stream, void *buf, uint32_t size)
+uint32_t ZCALLBACK fread_mem_func(ZIP_UNUSED voidpf opaque, voidpf stream, void *buf, uint32_t size)
 {
     ourmemory_t *mem = (ourmemory_t *)stream;
 
@@ -78,7 +78,7 @@ uint32_t ZCALLBACK fread_mem_func(voidpf opaque, voidpf stream, void *buf, uint3
     return size;
 }
 
-uint32_t ZCALLBACK fwrite_mem_func(voidpf opaque, voidpf stream, const void *buf, uint32_t size)
+uint32_t ZCALLBACK fwrite_mem_func(ZIP_UNUSED voidpf opaque, voidpf stream, const void *buf, uint32_t size)
 {
     ourmemory_t *mem = (ourmemory_t *)stream;
     uint32_t newmemsize = 0;
@@ -110,13 +110,13 @@ uint32_t ZCALLBACK fwrite_mem_func(voidpf opaque, voidpf stream, const void *buf
     return size;
 }
 
-long ZCALLBACK ftell_mem_func(voidpf opaque, voidpf stream)
+long ZCALLBACK ftell_mem_func(ZIP_UNUSED voidpf opaque, voidpf stream)
 {
     ourmemory_t *mem = (ourmemory_t *)stream;
     return mem->cur_offset;
 }
 
-long ZCALLBACK fseek_mem_func(voidpf opaque, voidpf stream, uint32_t offset, int origin)
+long ZCALLBACK fseek_mem_func(ZIP_UNUSED voidpf opaque, voidpf stream, uint32_t offset, int origin)
 {
     ourmemory_t *mem = (ourmemory_t *)stream;
     uint32_t new_pos = 0;
@@ -141,13 +141,13 @@ long ZCALLBACK fseek_mem_func(voidpf opaque, voidpf stream, uint32_t offset, int
     return 0;
 }
 
-int ZCALLBACK fclose_mem_func(voidpf opaque, voidpf stream)
+int ZCALLBACK fclose_mem_func(ZIP_UNUSED voidpf opaque, ZIP_UNUSED voidpf stream)
 {
     /* Even with grow = 1, caller must always free() memory */
     return 0;
 }
 
-int ZCALLBACK ferror_mem_func(voidpf opaque, voidpf stream)
+int ZCALLBACK ferror_mem_func(ZIP_UNUSED voidpf opaque, ZIP_UNUSED voidpf stream)
 {
     /* We never return errors */
     return 0;

--- a/zip.h
+++ b/zip.h
@@ -51,12 +51,6 @@ typedef voidp zipFile;
 #define ZIP_BADZIPFILE                  (-103)
 #define ZIP_INTERNALERROR               (-104)
 
-#ifdef __GNUC__
-#  define ZIP_UNUSED __attribute__((__unused__))
-#else
-#  define ZIP_UNUSED
-#endif
-
 #ifndef DEF_MEM_LEVEL
 #  if MAX_MEM_LEVEL >= 8
 #    define DEF_MEM_LEVEL 8


### PR DESCRIPTION
Fix all the unused parameter warnings generated by -Wunused-parameter on macOS with Xcode 9.