### PR TITLE
Clear the tm struct properly to avoid a compiler warning

### DIFF
--- a/minishared.c
+++ b/minishared.c
@@ -143,7 +143,8 @@ time_t dosdate_to_time_t(uint64_t dos_date)
 
 uint32_t tm_to_dosdate(const struct tm *ptm)
 {
-    struct tm fixed_tm = { 0 };
+    struct tm fixed_tm;
+    memset(&fixed_tm, 0, sizeof(fixed_tm));
 
     /* Years supported:
     * [00, 79]      (assumed to be between 2000 and 2079)


### PR DESCRIPTION
Clear the tm struct properly to avoid compiler warning "missing field 'tm_min' initializer" when using -Wmissing-field-initializers