### PR TITLE
Podspec for 1.3.0

### DIFF
--- a/Minizip.podspec
+++ b/Minizip.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'Minizip'
-  s.version  = '1.2.0'
+  s.version  = '1.3.0'
   s.license  = 'zlib'
   s.summary  = 'Minizip contrib in zlib with latest bug fixes that supports PKWARE disk spanning, AES encryption, and IO buffering'
   s.description = <<-DESC
@@ -17,16 +17,21 @@ DESC
   s.libraries = 'z'
 
   s.subspec 'Core' do |sp|
-    sp.source_files = '{ioapi,ioapi_mem,ioapi_buf,unzip,zip,crypt}.{c,h}'
+    sp.source_files = '{mz_strm,mz_strm_mem,mz_strm_buf,mz_unzip,mz_zip,mz_strm_crypt,mz_strm_posix,mz_strm_zlib}.{c,h}'
   end
 
   s.subspec 'AES' do |sp|
     sp.dependency 'Minizip/Core'
-    sp.source_files = 'aes/*.{c,h}'
+    sp.source_files = 'lib/aes/*.{c,h}', 'mz_strm_aes.{c,h}'
   end
-  
-  s.subspec 'minishared' do |sp|
+
+  s.subspec 'BZIP2' do |sp|
     sp.dependency 'Minizip/Core'
-    sp.source_files = 'minishared.{c,h}'
+    sp.source_files = 'lib/bzip2/*.{c,h}', 'mz_strm_bzip.{c,h}'
+  end
+
+  s.subspec 'LZMA' do |sp|
+    sp.dependency 'Minizip/Core'
+    sp.source_files = 'lib/liblzma/*.{c,h}', 'mz_strm_lzma.{c,h}'
   end
 end


### PR DESCRIPTION
I've removed the subspec for minishared, as apparently it's tools are now included in mz_strm.h.
