### PR TITLE
mz_compat.h: add type zipcharpc for compatibility

### DIFF
--- a/src/mz_compat.h
+++ b/src/mz_compat.h
@@ -75,6 +75,7 @@ typedef voidp zipFile;
 
 typedef void *zlib_filefunc_def;
 typedef void *zlib_filefunc64_def;
+typedef const char *zipcharpc;
 
 /***************************************************************************/
 


### PR DESCRIPTION
with original zlib/contrib/minizip API