### PR TITLE
"mz_error.h" no longer exists

### DIFF
--- a/src/mz_compat.c
+++ b/src/mz_compat.c
@@ -14,7 +14,7 @@
 #include <stdint.h>
 #include <string.h>
 
-#include "mz_error.h"
+#include "mz.h"
 #include "mz_os.h"
 #include "mz_strm.h"
 #include "mz_strm_zlib.h"


### PR DESCRIPTION
mz_compat.c fails to compile because "mz_error.h" no longer exists.  It should include "mz.h" instead.