### PR TITLE
Include "errno.h" to define EEXIST

### DIFF
--- a/src/mz_os_win32.c
+++ b/src/mz_os_win32.c
@@ -14,6 +14,7 @@
 #include <string.h>
 #include <time.h>
 #include <direct.h>
+#include <errno.h>
 
 #include <windows.h>
 #include <wincrypt.h>


### PR DESCRIPTION
When compiling under mingw-w64, "errno.h" must be included to define EEXIST