### PR TITLE
Fixes for the mz_compat layer.

### DIFF
--- a/src/minizip.c
+++ b/src/minizip.c
@@ -595,7 +595,7 @@ int main(int argc, char *argv[])
                 if ((c == 's') || (c == 'S'))
                     options.aes = 1;
 #endif
-                if (((c == 'k') || (c == 'k')) && (i + 1 < argc))
+                if (((c == 'k') || (c == 'K')) && (i + 1 < argc))
                 {
                     disk_size = atoi(argv[i + 1]) * 1024;
                     i += 1;

--- a/src/mz_compat.c
+++ b/src/mz_compat.c
@@ -282,6 +282,7 @@ extern unzFile ZEXPORT unzOpen2_64(const void *path, zlib_filefunc64_def *pzlib_
     compat->handle = handle;
     compat->stream = stream;
 
+    mz_zip_goto_first_entry(compat->handle);
     return (unzFile)compat;
 }
 

--- a/src/mz_compat.c
+++ b/src/mz_compat.c
@@ -493,7 +493,13 @@ extern int ZEXPORT unzGetCurrentFileInfo64(unzFile file, unz_file_info64 * pfile
             if (bytes_to_copy > file_info->filename_size)
                 bytes_to_copy = file_info->filename_size;
             memcpy(filename, file_info->filename, bytes_to_copy);
+            /* Ensure NULL termination for MiniZip 1.x compatibility. */
+            if (file_info->filename_size < filename_size)
+            {
+                filename[file_info->filename_size] = 0;
+            }
         }
+
         if (extrafield_size > 0 && extrafield != NULL)
         {
             bytes_to_copy = extrafield_size;
@@ -501,12 +507,18 @@ extern int ZEXPORT unzGetCurrentFileInfo64(unzFile file, unz_file_info64 * pfile
                 bytes_to_copy = file_info->extrafield_size;
             memcpy(extrafield, file_info->extrafield, bytes_to_copy);
         }
+
         if (comment_size > 0 && comment != NULL)
         {
             bytes_to_copy = comment_size;
             if (bytes_to_copy > file_info->comment_size)
                 bytes_to_copy = file_info->comment_size;
             memcpy(comment, file_info->comment, bytes_to_copy);
+            /* Ensure NULL termination for MiniZip 1.x compatibility. */
+            if (file_info->comment_size < comment_size)
+            {
+                comment[file_info->comment_size] = 0;
+            }
         }
     }
     return err;

--- a/src/mz_compat.c
+++ b/src/mz_compat.c
@@ -296,7 +296,10 @@ extern int ZEXPORT unzClose(unzFile file)
     err = mz_zip_close(compat->handle);
 
     if (compat->stream != NULL)
+    {
+        mz_stream_close(compat->stream);
         mz_stream_delete(&compat->stream);
+    }
 
     free(compat);
 

--- a/src/mz_compat.c
+++ b/src/mz_compat.c
@@ -57,7 +57,7 @@ extern zipFile ZEXPORT zipOpen2_64(const void *path, int append, const char **gl
     void *handle = NULL;
     void *stream = NULL;
 
-    if (mz_stream_create(&stream, (mz_stream_vtbl *)pzlib_filefunc_def) == NULL)
+    if (mz_stream_create(&stream, (mz_stream_vtbl *)*pzlib_filefunc_def) == NULL)
         return NULL;
 
     switch (append)
@@ -261,7 +261,7 @@ extern unzFile ZEXPORT unzOpen2_64(const void *path, zlib_filefunc64_def *pzlib_
     void *handle = NULL;
     void *stream = NULL;
 
-    if (mz_stream_create(&stream, (mz_stream_vtbl *)pzlib_filefunc_def) == NULL)
+    if (mz_stream_create(&stream, (mz_stream_vtbl *)*pzlib_filefunc_def) == NULL)
         return NULL;
     
     if (mz_stream_open(stream, path, mode) != MZ_OK)
@@ -538,37 +538,37 @@ extern int ZEXPORT unzLocateFile(unzFile file, const char *filename, unzFileName
 void fill_fopen_filefunc(zlib_filefunc_def *pzlib_filefunc_def)
 {
     if (pzlib_filefunc_def != NULL)
-        pzlib_filefunc_def = mz_stream_os_get_interface();
+        *pzlib_filefunc_def = mz_stream_os_get_interface();
 }
 
 void fill_fopen64_filefunc(zlib_filefunc64_def *pzlib_filefunc_def)
 {
     if (pzlib_filefunc_def != NULL)
-        pzlib_filefunc_def = mz_stream_os_get_interface();
+        *pzlib_filefunc_def = mz_stream_os_get_interface();
 }
 
 void fill_win32_filefunc(zlib_filefunc_def *pzlib_filefunc_def)
 {
     if (pzlib_filefunc_def != NULL)
-        pzlib_filefunc_def = mz_stream_os_get_interface();
+        *pzlib_filefunc_def = mz_stream_os_get_interface();
 }
 
 void fill_win32_filefunc64(zlib_filefunc64_def *pzlib_filefunc_def)
 {
     if (pzlib_filefunc_def != NULL)
-        pzlib_filefunc_def = mz_stream_os_get_interface();
+        *pzlib_filefunc_def = mz_stream_os_get_interface();
 }
 
 void fill_win32_filefunc64A(zlib_filefunc64_def *pzlib_filefunc_def)
 {
     if (pzlib_filefunc_def != NULL)
-        pzlib_filefunc_def = mz_stream_os_get_interface();
+        *pzlib_filefunc_def = mz_stream_os_get_interface();
 }
 
 void fill_win32_filefunc64W(zlib_filefunc64_def *pzlib_filefunc_def)
 {
     // NOTE: You should no longer pass in widechar string to open function
     if (pzlib_filefunc_def != NULL)
-        pzlib_filefunc_def = mz_stream_os_get_interface();
+        *pzlib_filefunc_def = mz_stream_os_get_interface();
 }
 

--- a/test/test.c
+++ b/test/test.c
@@ -151,7 +151,7 @@ void test_compress(char *method, mz_stream_create_cb create_compress)
 
         mz_stream_delete(&deflate_stream);
 
-        printf("%s compressed from %d to %d\n", filename, (uint32_t)total_in, (uint32_t)total_out);
+        printf("%s compressed from %u to %u\n", filename, (uint32_t)total_in, (uint32_t)total_out);
 
         mz_stream_os_close(out_stream);
     }
@@ -175,7 +175,7 @@ void test_compress(char *method, mz_stream_create_cb create_compress)
 
         mz_stream_os_close(in_stream);
 
-        printf("%s uncompressed from %d to %d\n", filename, (uint32_t)total_in, (uint32_t)total_out);
+        printf("%s uncompressed from %u to %u\n", filename, (uint32_t)total_in, (uint32_t)total_out);
     }
 
     mz_stream_os_delete(&in_stream);


### PR DESCRIPTION
While trying to update my ROM Properties Page plugin to use MiniZip 2.2.3, I encountered several issues in the mz_compat layer that caused crashes and other random problems. One of these problems were already fixed here before I had the chance to send the PR (build without encryption).

This PR has:
* Correctly dereference `pzlib_filefunc_def`. This is only an issue if the MiniZip 1.x vtable is set manually, which I was doing in order to handle Unicode filenames on Windows.
* unzClose(): Close the file handle. A similar fix for zipClose2_64() was applied in commit 053d00c451e102464e680069cd1ed6cae4171dc6.
* unzGetCurrentFileInfo64(): Make sure `filename` and `comment` are NULL-terminated.
* unzOpen2_64(): Go to the first file immediately.
* Some printf() fixes found with cppcheck-1.81.