### PR TITLE
mz_strm_posix: Fix return value checking for POSIX stdio functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,7 +89,7 @@ if(UNIX)
     add_definitions(-D__USE_FILE_OFFSET64)
     add_definitions(-D__USE_LARGEFILE64)
     add_definitions(-D_LARGEFILE64_SOURCE)
-    add_definitions(-D_FILE_OFFSET_BIT=64)
+    add_definitions(-D_FILE_OFFSET_BITS=64)
 
     find_package(PkgConfig REQUIRED)
 

--- a/src/mz_strm_posix.c
+++ b/src/mz_strm_posix.c
@@ -113,9 +113,9 @@ int32_t mz_stream_posix_read(void *stream, void *buf, int32_t size)
 {
     mz_stream_posix *posix = (mz_stream_posix*)stream;
     int32_t read = (int32_t)fread(buf, 1, (size_t)size, posix->handle);
-    if (read < 0)
+    if (read < size && ferror(posix->handle))
     {
-        posix->error = ferror(posix->handle);
+        posix->error = errno;
         return MZ_STREAM_ERROR;
     }
     return read;
@@ -125,9 +125,9 @@ int32_t mz_stream_posix_write(void *stream, const void *buf, int32_t size)
 {
     mz_stream_posix *posix = (mz_stream_posix*)stream;
     int32_t written = (int32_t)fwrite(buf, 1, (size_t)size, posix->handle);
-    if (written < 0)
+    if (written < size && ferror(posix->handle))
     {
-        posix->error = ferror(posix->handle);
+        posix->error = errno;
         return MZ_STREAM_ERROR;
     }
     return written;
@@ -139,7 +139,7 @@ int64_t mz_stream_posix_tell(void *stream)
     int64_t position = ftello64(posix->handle);
     if (position == -1)
     {
-        posix->error = ferror(posix->handle);
+        posix->error = errno;
         return MZ_STREAM_ERROR;
     }
     return position;
@@ -167,7 +167,7 @@ int32_t mz_stream_posix_seek(void *stream, int64_t offset, int32_t origin)
 
     if (fseeko64(posix->handle, offset, fseek_origin) != 0)
     {
-        posix->error = ferror(posix->handle);
+        posix->error = errno;
         return MZ_STREAM_ERROR;
     }
 


### PR DESCRIPTION
This PR fixes a few functions in `mz_strm_posix.c` to check for the right failure conditions in the POSIX stdio API.