### PR TITLE
CMakeLists.txt: Use add_compile_options() instead of modifying CMAKE_C_FLAGS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,7 @@ if("${CMAKE_SYSTEM_NAME}" STREQUAL "WindowsStore")
 endif()
 
 if(UNIX)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -O3")
+    add_compile_options(-fPIC -O3)
 
     list(APPEND MINIZIP_SRC "src/mz_os_posix.c")
     list(APPEND MINIZIP_PUBLIC_HEADERS "src/mz_os_posix.h")
@@ -276,7 +276,7 @@ if(USE_LZMA)
 endif()
 
 if(CMAKE_C_COMPILER MATCHES ".*clang")
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -msse3 -msse4.1 -maes")
+    add_compile_options(-msse3 -msse4.1 -maes)
 endif()
 
 # Create minizip library


### PR DESCRIPTION
This allows a parent project to use minizip via:

    add_subdirectory(path/to/minizip)

without the compiler flags of the parent project being affected.