### PR TITLE
mz_zip.c: Fix incorrect size of data descriptor fields

### DIFF
--- a/src/mz_zip.c
+++ b/src/mz_zip.c
@@ -1405,16 +1405,16 @@ extern int32_t mz_zip_entry_close_raw(void *handle, uint64_t uncompressed_size, 
             if (err == MZ_OK)
             {
                 if (zip->file_info.uncompressed_size <= UINT32_MAX)
-                    err = mz_stream_write_uint64(zip->stream, compressed_size);
-                else
                     err = mz_stream_write_uint32(zip->stream, (uint32_t)compressed_size);
+                else
+                    err = mz_stream_write_uint64(zip->stream, compressed_size);
             }
             if (err == MZ_OK)
             {
                 if (zip->file_info.uncompressed_size <= UINT32_MAX)
-                    err = mz_stream_write_uint64(zip->stream, uncompressed_size);
-                else
                     err = mz_stream_write_uint32(zip->stream, (uint32_t)uncompressed_size);
+                else
+                    err = mz_stream_write_uint64(zip->stream, uncompressed_size);
             }
         }
 


### PR DESCRIPTION
Previously, the conditions for writing 32-bit vs 64-bit data descriptor
fields were swapped. If the size was smaller than UINT32_MAX, a 64-bit
integer would be written, and if the size was larger, then a truncated
32-bit integer would be written. This prevented programs that don't have
support for the central directory (like busybox) from reading files
created by minizip.