### PR TITLE
mz_zip.c: Both data descriptor size fields must be the same type

### DIFF
--- a/src/mz_zip.c
+++ b/src/mz_zip.c
@@ -1402,18 +1402,18 @@ extern int32_t mz_zip_entry_close_raw(void *handle, uint64_t uncompressed_size, 
             err = mz_stream_write_uint32(zip->stream, MZ_ZIP_MAGIC_DATADESCRIPTOR);
             if (err == MZ_OK)
                 err = mz_stream_write_uint32(zip->stream, crc32);
-            if (err == MZ_OK)
+            if (zip->file_info.uncompressed_size <= UINT32_MAX && zip->file_info.uncompressed_size <= UINT32_MAX)
             {
-                if (zip->file_info.uncompressed_size <= UINT32_MAX)
+                if (err == MZ_OK)
                     err = mz_stream_write_uint32(zip->stream, (uint32_t)compressed_size);
-                else
-                    err = mz_stream_write_uint64(zip->stream, compressed_size);
-            }
-            if (err == MZ_OK)
-            {
-                if (zip->file_info.uncompressed_size <= UINT32_MAX)
+                if (err == MZ_OK)
                     err = mz_stream_write_uint32(zip->stream, (uint32_t)uncompressed_size);
-                else
+            }
+            else
+            {
+                if (err == MZ_OK)
+                    err = mz_stream_write_uint64(zip->stream, compressed_size);
+                if (err == MZ_OK)
                     err = mz_stream_write_uint64(zip->stream, uncompressed_size);
             }
         }


### PR DESCRIPTION
Section 4.3.9.1 of the standard says:

    For ZIP64(tm) format archives, the compressed and uncompressed
    sizes are 8 bytes each.

This updates the data descriptor code to use 64 bit integers if either
the compressed size or the compressed size is greater than UINT32_MAX.