### PR TITLE
Support reading 65kb+ entries on most machines.

### DIFF
--- a/src/mz_strm_zlib.c
+++ b/src/mz_strm_zlib.c
@@ -129,7 +129,7 @@ int32_t mz_stream_zlib_read(void *stream, void *buf, int32_t size)
 
 
     zlib->zstream.next_out = (uint8_t*)buf;
-    zlib->zstream.avail_out = (uint16_t)size;
+    zlib->zstream.avail_out = (uint32_t)size;
 
     do
     {

--- a/src/mz_zip.c
+++ b/src/mz_zip.c
@@ -1314,7 +1314,7 @@ extern int32_t mz_zip_entry_read(void *handle, void *buf, uint32_t len)
 
     if (zip == NULL || zip->entry_opened == 0)
         return MZ_PARAM_ERROR;
-    if (len > UINT16_MAX) // Zlib limitation
+    if (sizeof(unsigned int) == 2 && len > UINT16_MAX) // Zlib limitation
         return MZ_PARAM_ERROR;
     if (len == 0 || zip->file_info.uncompressed_size == 0)
         return 0;


### PR DESCRIPTION
Test for 16-bit integers before imposing 16-bit Zlib restrictions. Fixes #227.