### PR TITLE
keep FILE_SHARE_READ if MZ_OPEN_MODE_READ

### DIFF
--- a/src/mz_strm_win32.c
+++ b/src/mz_strm_win32.c
@@ -82,7 +82,6 @@ int32_t mz_stream_win32_open(void *stream, const char *path, int32_t mode)
     {
         desired_access = GENERIC_READ;
         creation_disposition = OPEN_EXISTING;
-        share_mode &= FILE_SHARE_WRITE;
     }
     else if (mode & MZ_OPEN_MODE_APPEND)
     {


### PR DESCRIPTION
mz_stream_win32_open opens the stream in exclusively mode if mode & MZ_OPEN_MODE_READWRITE) == MZ_OPEN_MODE_READ.
Likely it is a bug, and it is not clear what is expected behavior.
Just keep FILE_SHARE_READ to allow shared read access to the stream.