### PR TITLE
Fix ntfs extra field

### DIFF
--- a/src/mz_compat.c
+++ b/src/mz_compat.c
@@ -106,7 +106,7 @@ extern int ZEXPORT zipOpenNewFileInZip5(zipFile file, const char *filename, cons
     ZIP_UNUSED uint32_t crc_for_crypting,  uint16_t version_madeby, uint16_t flag_base, int zip64)
 {
     mz_compat *compat = (mz_compat *)file;
-    mz_zip_file file_info;
+    mz_zip_file file_info = { 0 };
 
     if (compat == NULL)
         return MZ_PARAM_ERROR;

--- a/src/mz_zip.c
+++ b/src/mz_zip.c
@@ -881,17 +881,11 @@ static int32_t mz_zip_entry_write_header(void *stream, uint8_t local, mz_zip_fil
         extrafield_size += 4 + 7;
 #endif
     // NTFS timestamps
-    if (file_info->modified_date != 0)
-        extrafield_ntfs_size += 8;
-    if (file_info->accessed_date != 0)
-        extrafield_ntfs_size += 8;
-    if (file_info->creation_date != 0)
-        extrafield_ntfs_size += 8;
-
-    if (extrafield_ntfs_size > 4)
+    if (file_info->modified_date != 0 &&
+        file_info->accessed_date != 0 &&
+        file_info->creation_date != 0)
     {
-        extrafield_ntfs_size += 4 + 4;
-
+        extrafield_ntfs_size += 8 + 8 + 8 + 4 + 2 + 2;
         extrafield_size += 4;
         extrafield_size += extrafield_ntfs_size;
     }
@@ -1006,17 +1000,17 @@ static int32_t mz_zip_entry_write_header(void *stream, uint8_t local, mz_zip_fil
             err = mz_stream_write_uint16(stream, 0x01);
         if (err == MZ_OK)
             err = mz_stream_write_uint16(stream, extrafield_ntfs_size - 8);
-        if ((err == MZ_OK) && (file_info->modified_date != 0))
+        if (err == MZ_OK)
         {
             mz_zip_unix_to_ntfs_time(file_info->modified_date, &ntfs_time);
             err = mz_stream_write_uint64(stream, ntfs_time);
         }
-        if ((err == MZ_OK) && (file_info->accessed_date != 0))
+        if (err == MZ_OK)
         {
             mz_zip_unix_to_ntfs_time(file_info->accessed_date, &ntfs_time);
             err = mz_stream_write_uint64(stream, ntfs_time);
         }
-        if ((err == MZ_OK) && (file_info->creation_date != 0))
+        if (err == MZ_OK)
         {
             mz_zip_unix_to_ntfs_time(file_info->creation_date, &ntfs_time);
             err = mz_stream_write_uint64(stream, ntfs_time);

--- a/src/mz_zip.c
+++ b/src/mz_zip.c
@@ -770,17 +770,17 @@ static int32_t mz_zip_entry_read_header(void *stream, uint8_t local, mz_zip_file
                     if (err == MZ_OK)
                         err = mz_stream_read_uint16(file_info_stream, &ntfs_attrib_size);
 
-                    if (ntfs_attrib_id == 0x01 && ntfs_attrib_size >= 8)
+                    if (ntfs_attrib_id == 0x01 && ntfs_attrib_size == 24)
                     {
                         err = mz_stream_read_uint64(file_info_stream, &ntfs_time);
                         mz_zip_ntfs_to_unix_time(ntfs_time, &file_info->modified_date);
 
-                        if ((err == MZ_OK) && (ntfs_attrib_size >= 16))
+                        if (err == MZ_OK)
                         {
                             err = mz_stream_read_uint64(file_info_stream, &ntfs_time);
                             mz_zip_ntfs_to_unix_time(ntfs_time, &file_info->accessed_date);
                         }
-                        if ((err == MZ_OK) && (ntfs_attrib_size >= 24))
+                        if (err == MZ_OK)
                         {
                             err = mz_stream_read_uint64(file_info_stream, &ntfs_time);
                             mz_zip_ntfs_to_unix_time(ntfs_time, &file_info->creation_date);

--- a/src/mz_zip.c
+++ b/src/mz_zip.c
@@ -770,7 +770,7 @@ static int32_t mz_zip_entry_read_header(void *stream, uint8_t local, mz_zip_file
                     if (err == MZ_OK)
                         err = mz_stream_read_uint16(file_info_stream, &ntfs_attrib_size);
 
-                    if (ntfs_attrib_id == 0x01 && ntfs_attrib_size == 24)
+                    if ((ntfs_attrib_id == 0x01) && (ntfs_attrib_size == 24))
                     {
                         err = mz_stream_read_uint64(file_info_stream, &ntfs_time);
                         mz_zip_ntfs_to_unix_time(ntfs_time, &file_info->modified_date);

--- a/src/mz_zip.c
+++ b/src/mz_zip.c
@@ -881,9 +881,9 @@ static int32_t mz_zip_entry_write_header(void *stream, uint8_t local, mz_zip_fil
         extrafield_size += 4 + 7;
 #endif
     // NTFS timestamps
-    if (file_info->modified_date != 0 &&
-        file_info->accessed_date != 0 &&
-        file_info->creation_date != 0)
+    if ((file_info->modified_date != 0) &&
+        (file_info->accessed_date != 0) &&
+        (file_info->creation_date != 0))
     {
         extrafield_ntfs_size += 8 + 8 + 8 + 4 + 2 + 2;
         extrafield_size += 4;


### PR DESCRIPTION
Currently the implementation for NTFS file times extra field writes only the timestamps different from zero:

https://github.com/nmoinvaz/minizip/blob/7a3820c53912d3c004c493b0ad1811864ccfe8c1/src/mz_zip.c#L883-L889

From the APPNOTE.TXT I understand that the extra field should contain all the three timestamps (or not be used at all). Since I'm no expert, I peeked at a few ZIP libraries/utilities source code. Multiplatform utilities (like InfoZIP) usually skip the field altogether or do not parse its contents. So I focused on libraries targeting the Windows system and (IMHO) are the most relevant. To cite some examples, SharpZipLib will ignore the extra field if tag data length is different from 24 bytes. DotNetZip will fail with an exception if the extra field total length is different from 32 bytes. Other less popular libraries will do the same, either ignore the field or fail if the field is not complete with the three timestamps.

This change will write an NTFS extra field only if `modified_date`, `accessed_date` and `creation_date` are different from zero. Similarly, when reading an NTFS extra field, it will only be parsed if the three timestamps are present, otherwise the field is ignored, so older archives which may contain less than three timestamps won't break when trying to decompress.

Finally, `zipOpenNewFileInZip5` in `mz_compat.c` now initializes `file_info` struct to zero. Before this change, since the `if` body cited below only initializes `modified_date`, the variables `accessed_date` and `creation_date` have a great chance of containing non-zeroed values which will be written to the extra field, potentially breaking other decompressors which parse and try to convert those values to timestamps.

https://github.com/nmoinvaz/minizip/blob/7a3820c53912d3c004c493b0ad1811864ccfe8c1/src/mz_compat.c#L116-L121

Regards