### PR TITLE
Fixes #233

### DIFF
--- a/src/mz_zip.c
+++ b/src/mz_zip.c
@@ -1159,7 +1159,7 @@ static int32_t mz_zip_entry_open_int(void *handle, int16_t compression_method, i
         }
         else
         {
-            if (zip->file_info.flag & MZ_ZIP_FLAG_ENCRYPTED || zip->compression_method == MZ_COMPRESS_METHOD_RAW)
+            if (zip->compression_method == MZ_COMPRESS_METHOD_RAW || zip->file_info.flag & MZ_ZIP_FLAG_ENCRYPTED)
             {
                 max_total_in = zip->file_info.compressed_size;
                 if (mz_stream_get_prop_int64(zip->crypt_stream, MZ_STREAM_PROP_FOOTER_SIZE, &footer_size) == MZ_OK)
@@ -1168,8 +1168,7 @@ static int32_t mz_zip_entry_open_int(void *handle, int16_t compression_method, i
                     max_total_in -= total_in;
                 mz_stream_set_prop_int64(zip->compress_stream, MZ_STREAM_PROP_TOTAL_IN_MAX, max_total_in);
             }
-            if (zip->compression_method == MZ_COMPRESS_METHOD_LZMA &&
-                (zip->file_info.flag & MZ_ZIP_FLAG_LZMA_EOS_MARKER) == 0)
+            if (zip->compression_method == MZ_COMPRESS_METHOD_LZMA && (zip->file_info.flag & MZ_ZIP_FLAG_LZMA_EOS_MARKER) == 0)
             {
                 mz_stream_set_prop_int64(zip->compress_stream, MZ_STREAM_PROP_TOTAL_IN_MAX, zip->file_info.compressed_size);
                 mz_stream_set_prop_int64(zip->compress_stream, MZ_STREAM_PROP_TOTAL_OUT_MAX, zip->file_info.uncompressed_size);

--- a/src/mz_zip.c
+++ b/src/mz_zip.c
@@ -1168,6 +1168,12 @@ static int32_t mz_zip_entry_open_int(void *handle, int16_t compression_method, i
                     max_total_in -= total_in;
                 mz_stream_set_prop_int64(zip->compress_stream, MZ_STREAM_PROP_TOTAL_IN_MAX, max_total_in);
             }
+            if (zip->compression_method == MZ_COMPRESS_METHOD_LZMA &&
+                (zip->file_info.flag & MZ_ZIP_FLAG_LZMA_EOS_MARKER) == 0)
+            {
+                mz_stream_set_prop_int64(zip->compress_stream, MZ_STREAM_PROP_TOTAL_IN_MAX, zip->file_info.compressed_size);
+                mz_stream_set_prop_int64(zip->compress_stream, MZ_STREAM_PROP_TOTAL_OUT_MAX, zip->file_info.uncompressed_size);
+            }
         }
 
         mz_stream_set_base(zip->compress_stream, zip->crypt_stream);


### PR DESCRIPTION
Fixes decompressing LZMA streams without EOS marker, which is indicated by bit 1 turned off in general purpose bit flag (APPNOTE.TXT section 4.4.4).
I have absolutely no experience using LZMA library so it would be good if someone could check this. The only documentation I found was the Javadoc for the XZ library, which states that when EOS is missing, the library user must know both the compressed size to limit the compressed stream reads, and the uncompressed size to limit the output buffer writes, otherwise the decompressor might produce more output than the original (e.g., when decompressing nices/DirectX-setup/DSETUP.dll from the test file, an extra 0x00 byte is produced).