### PR TITLE
Fix Unknown type name 'z_crc_t' in minizip 2.x

### DIFF
--- a/src/mz_strm_crypt.c
+++ b/src/mz_strm_crypt.c
@@ -38,6 +38,10 @@
 
 #define RAND_HEAD_LEN  12
 
+#if ZLIB_VERNUM < 0x1270 //define z_crc_t in zlib 1.2.5 and less
+typedef unsigned long z_crc_t;
+#endif
+
 /***************************************************************************/
 
 mz_stream_vtbl mz_stream_crypt_vtbl = {

--- a/src/mz_strm_crypt.c
+++ b/src/mz_strm_crypt.c
@@ -38,10 +38,6 @@
 
 #define RAND_HEAD_LEN  12
 
-#if ZLIB_VERNUM < 0x1270 //define z_crc_t in zlib 1.2.5 and less
-typedef unsigned long z_crc_t;
-#endif
-
 /***************************************************************************/
 
 mz_stream_vtbl mz_stream_crypt_vtbl = {
@@ -59,6 +55,10 @@ mz_stream_vtbl mz_stream_crypt_vtbl = {
 };
 
 /***************************************************************************/
+
+#if ZLIB_VERNUM < 0x1270 // Define z_crc_t in zlib 1.2.5 and less
+typedef unsigned long z_crc_t;
+#endif
 
 typedef struct mz_stream_crypt_s {
     mz_stream       stream;


### PR DESCRIPTION
Reapplies https://github.com/nmoinvaz/minizip/pull/136 to minizip 2.x from @Coeur into minizip 2.x to support Xcode 7. 