### PR TITLE
Minor fixes for mingw cross-compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -324,6 +324,10 @@ add_library(${PROJECT_NAME}
                 ${BZIP2_SRC} ${BZIP2_PUBLIC_HEADERS}
                 ${LZMA_SRC} ${LZMA_PUBLIC_HEADERS})
 
+if (MINGW AND BUILD_SHARED_LIBS)
+  set_target_properties(${PROJECT_NAME} PROPERTIES ARCHIVE_OUTPUT_NAME "minizip")
+endif ()
+
 set_target_properties(${PROJECT_NAME} PROPERTIES LINKER_LANGUAGE C PREFIX ""
                       POSITION_INDEPENDENT_CODE 1)
 if(USE_ZLIB)

--- a/minizip.pc.cmakein
+++ b/minizip.pc.cmakein
@@ -8,6 +8,6 @@ Name: minizip
 Description: Minizip zip file manipulation library
 Version: @VERSION@
 
-Requires:
-Libs: -L${libdir} -L${sharedlibdir} -lz -lminizip
+Requires: zlib
+Libs: -L${libdir} -L${sharedlibdir} -lminizip
 Cflags: -I${includedir}


### PR DESCRIPTION
 - cmake automatically adds `lib` to the project name for shared mingw builds and produces `liblibminizip.dll.a`
  - `-lz` needs to come after `-lminizip` for static linking