### PR TITLE
Fix comment length overflow.

### DIFF
--- a/src/mz_compat.c
+++ b/src/mz_compat.c
@@ -331,7 +331,7 @@ extern int ZEXPORT unzGetGlobalInfo(unzFile file, unz_global_info* pglobal_info3
     {
         pglobal_info32->number_entry = (uint32_t)global_info64.number_entry;
         pglobal_info32->size_comment = global_info64.size_comment;
-        pglobal_info32->number_disk_with_CD = global_info64.number_disk_with_CD;
+        pglobal_info32->number_disk_with_CD = (uint32_t)global_info64.number_disk_with_CD;
     }
     return err;
 }

--- a/src/mz_compat.h
+++ b/src/mz_compat.h
@@ -176,7 +176,7 @@ typedef voidp unzFile;
 typedef struct unz_global_info64_s
 {
     uint64_t number_entry;          // total number of entries in the central dir on this disk 
-    uint32_t number_disk_with_CD;   // number the the disk with central dir, used for spanning ZIP
+    uint64_t number_disk_with_CD;   // number the the disk with central dir, used for spanning ZIP
     uint16_t size_comment;          // size of the global comment of the zipfile 
 } unz_global_info64;
 


### PR DESCRIPTION
In MiniZip compatible layer there is an overflow.
```cpp
mz_zip_get_disk_number_with_cd(compat->handle, (int64_t *)&pglobal_info->number_disk_with_CD);
```
unz_global_info64_s struct is declared as
```cpp
uint64_t number_entry; 
uint32_t number_disk_with_CD;
uint16_t size_comment;
```
number_disk_with_CD must be 64-bit length otherwise will overflow into the other struct member.

