### PR TITLE
improve compatibility with original minizip

### DIFF
--- a/mz_compat.h
+++ b/mz_compat.h
@@ -79,11 +79,17 @@ typedef void *zlib_filefunc_def;
 typedef void *zlib_filefunc64_def;
 typedef const char *zipcharpc;
 
+typedef struct tm tm_unz;
+typedef struct tm tm_zip;
+
+typedef uint64_t ZPOS64_T;
+
 /***************************************************************************/
 
 typedef struct
 {
-    uint32_t    dos_date;
+    uint32_t    dosDate;
+    struct tm   tmz_date;
     uint16_t    internal_fa;        // internal file attributes        2 bytes
     uint32_t    external_fa;        // external file attributes        4 bytes
 } zip_fileinfo;
@@ -141,6 +147,7 @@ extern int ZEXPORT zipOpenNewFileInZip5(zipFile file, const char *filename, cons
 extern int ZEXPORT zipWriteInFileInZip(zipFile file, const void *buf, uint32_t len);
 
 extern int ZEXPORT zipCloseFileInZipRaw(zipFile file, uint32_t uncompressed_size, uint32_t crc32);
+extern int ZEXPORT zipCloseFileInZipRaw64(zipFile file, uint64_t uncompressed_size, uint32_t crc32);
 extern int ZEXPORT zipCloseFileInZip(zipFile file);
 extern int ZEXPORT zipCloseFileInZip64(zipFile file);
 
@@ -193,7 +200,8 @@ typedef struct unz_file_info64_s
     uint16_t version_needed;        // version needed to extract       2 bytes 
     uint16_t flag;                  // general purpose bit flag        2 bytes 
     uint16_t compression_method;    // compression method              2 bytes 
-    uint32_t dos_date;              // last mod file date in Dos fmt   4 bytes 
+    uint32_t dosDate;               // last mod file date in Dos fmt   4 bytes
+    struct tm tmu_date;
     uint32_t crc;                   // crc-32                          4 bytes 
     uint64_t compressed_size;       // compressed size                 8 bytes 
     uint64_t uncompressed_size;     // uncompressed size               8 bytes 
@@ -216,7 +224,8 @@ typedef struct unz_file_info_s
     uint16_t version_needed;        // version needed to extract       2 bytes 
     uint16_t flag;                  // general purpose bit flag        2 bytes 
     uint16_t compression_method;    // compression method              2 bytes 
-    uint32_t dos_date;              // last mod file date in Dos fmt   4 bytes 
+    uint32_t dosDate;               // last mod file date in Dos fmt   4 bytes
+    struct tm tmu_date;
     uint32_t crc;                   // crc-32                          4 bytes 
     uint32_t compressed_size;       // compressed size                 4 bytes 
     uint32_t uncompressed_size;     // uncompressed size               4 bytes 
@@ -263,6 +272,12 @@ extern int ZEXPORT unzGetCurrentFileInfo64(unzFile file, unz_file_info64 * pfile
 extern int ZEXPORT unzGoToFirstFile(unzFile file);
 extern int ZEXPORT unzGoToNextFile(unzFile file);
 extern int ZEXPORT unzLocateFile(unzFile file, const char *filename, unzFileNameComparer filename_compare_func);
+
+extern int64_t ZEXPORT unzGetOffset64(unzFile file);
+extern int32_t ZEXPORT unzGetOffset(unzFile file);
+extern int ZEXPORT unzSetOffset64(unzFile file, uint64_t pos);
+extern int ZEXPORT unzSetOffset(unzFile file, uint32_t pos);
+extern int ZEXPORT unzGetLocalExtrafield(unzFile file, voidp buf, unsigned len);
 
 /***************************************************************************/
 

--- a/mz_zip.h
+++ b/mz_zip.h
@@ -111,6 +111,12 @@ extern int32_t mz_zip_get_number_entry(void *handle, int64_t *number_entry);
 extern int32_t mz_zip_get_disk_number_with_cd(void *handle, int32_t *disk_number_with_cd);
 // Get the the disk number containing the central directory record
 
+extern int64_t mz_zip_get_entry(void *handle);
+// Return offset of the current entry in the zip file
+
+extern int32_t mz_zip_goto_entry(void *handle, uint64_t cd_pos);
+// Go to specified entry in the zip file
+
 extern int32_t mz_zip_goto_first_entry(void *handle);
 // Go to the first entry in the zip file 
 


### PR DESCRIPTION
* Fix NULL pointer dereference when calling `zipOpen*()` or `unzOpen2*()` with NULL filefunc table.
* Rename `dos_date` to `dosDate` in zip/unzip structures to be compatible with original minizip.
* Add tm struct timestamps to zip/unzip structures and populate them with the `dosDate` value for unzip and use the value passed into it on zip, if `dosDate` is zero (mimicing original minizip behaviour.)
* Change `zipWriteInFileInZip()` return value to be a status code (`ZIP_OK` or `ZIP_ERRNO`) instead of the number of bytes written. This way it's minizip compatible.
* Add `zipCloseFileInZipRaw64()` compatibility wrapper.
* Add these compatibility functions:
  `unzGetOffset()`
  `unzGetOffset64()`
  `unzSetOffset()`
  `unzSetOffset64()`
* Add stub for compatibility: `unzGetLocalExtrafield()`
   It will always return zero for now.
* Add original minizip types for compatiblity: `tm_unz`, `tm_zip`, `ZPOS64_T`
* Add these minizip (non-compatiblity) APIs:
  `mz_zip_get_entry()`
  `mz_zip_goto_entry()`
* `zipOpenNewFileInZip*()` to use the default filename of "-" if filename parameter was NULL. For minizip compatibility.
* Fix `mz_zip_entry_open_int()` and `mz_zip_entry_read_open()` failing with `MZ_PARAM_ERROR` in raw mode
* Add/cleanup some date-related comments
* `mz_zip_time_t_to_tm()` to clear the `tm` structure in case `localtime()` call failed.
* Fix `mz_zip_tm_to_dosdate()` to do the date validation on the normalized date (the year in particular), not on the raw value passed by the caller. This makes it work correctly when year is passed as-is, such as 1990.

The reference minizip was the version that comes with the latest zlib, currently at 1.2.11.