### PR TITLE
fix cast warning (seen with LLVM/Clang)

### DIFF
--- a/mz_zip.c
+++ b/mz_zip.c
@@ -1468,7 +1468,7 @@ extern int32_t mz_zip_get_number_entry(void *handle, int64_t *number_entry)
     return MZ_OK;
 }
 
-extern int32_t mz_zip_get_disk_number_with_cd(void *handle, int32_t *disk_number_with_cd)
+extern int32_t mz_zip_get_disk_number_with_cd(void *handle, uint32_t *disk_number_with_cd)
 {
     mz_zip *zip = (mz_zip *)handle;
     if (zip == NULL || disk_number_with_cd == NULL)

--- a/mz_zip.h
+++ b/mz_zip.h
@@ -108,7 +108,7 @@ extern int32_t mz_zip_entry_close(void *handle);
 extern int32_t mz_zip_get_number_entry(void *handle, int64_t *number_entry);
 // Get the total number of entries
 
-extern int32_t mz_zip_get_disk_number_with_cd(void *handle, int32_t *disk_number_with_cd);
+extern int32_t mz_zip_get_disk_number_with_cd(void *handle, uint32_t *disk_number_with_cd);
 // Get the the disk number containing the central directory record
 
 extern int64_t mz_zip_get_entry(void *handle);


### PR DESCRIPTION
```
mz_compat.c:390:62: warning: passing 'uint32_t *' (aka 'unsigned int *') to parameter of type
      'int32_t *' (aka 'int *') converts between pointers to integer types with different sign [-Wpointer-sign]
        err = mz_zip_get_disk_number_with_cd(compat->handle, &pglobal_info->number_disk_with_CD);
                                                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
mz_zip.h:112:70: note: passing argument to parameter 'disk_number_with_cd' here
extern int32_t mz_zip_get_disk_number_with_cd(void *handle, int32_t *disk_number_with_cd);
                                                                     ^
```