### PR TITLE
silence various warnings

### DIFF
--- a/mz_compat.c
+++ b/mz_compat.c
@@ -108,9 +108,9 @@ extern zipFile ZEXPORT zipOpen2_64(const void *path, int append, const char **gl
 }
 
 extern int ZEXPORT zipOpenNewFileInZip5(zipFile file, const char *filename, const zip_fileinfo *zipfi,
-    const void *extrafield_local, uint16_t size_extrafield_local, const void *extrafield_global,
+    ZIP_UNUSED const void *extrafield_local, ZIP_UNUSED uint16_t size_extrafield_local, const void *extrafield_global,
     uint16_t size_extrafield_global, const char *comment, uint16_t compression_method, int level,
-    int raw, int windowBits, int memLevel, int strategy, const char *password,
+    int raw, ZIP_UNUSED int windowBits, ZIP_UNUSED int memLevel, ZIP_UNUSED int strategy, const char *password,
     ZIP_UNUSED uint32_t crc_for_crypting,  uint16_t version_madeby, uint16_t flag_base, int zip64)
 {
     mz_compat *compat = (mz_compat *)file;
@@ -161,7 +161,7 @@ extern int ZEXPORT zipOpenNewFileInZip4_64(zipFile file, const char *filename, c
     const void *extrafield_local, uint16_t size_extrafield_local, const void *extrafield_global,
     uint16_t size_extrafield_global, const char *comment, uint16_t compression_method, int level,
     int raw, int windowBits, int memLevel,   int strategy, const char *password,
-    ZIP_UNUSED uint32_t crc_for_crypting, uint16_t version_madeby, uint16_t flag_base, int zip64)
+    uint32_t crc_for_crypting, uint16_t version_madeby, uint16_t flag_base, int zip64)
 {
     return zipOpenNewFileInZip5(file, filename, zipfi, extrafield_local, size_extrafield_local,
         extrafield_global, size_extrafield_global, comment, compression_method, level, raw, windowBits,
@@ -172,7 +172,7 @@ extern int ZEXPORT zipOpenNewFileInZip4(zipFile file, const char *filename, cons
     const void *extrafield_local, uint16_t size_extrafield_local, const void *extrafield_global,
     uint16_t size_extrafield_global, const char *comment, uint16_t compression_method, int level,
     int raw, int windowBits, int memLevel, int strategy, const char *password,
-    ZIP_UNUSED uint32_t crc_for_crypting, uint16_t version_madeby, uint16_t flag_base)
+    uint32_t crc_for_crypting, uint16_t version_madeby, uint16_t flag_base)
 {
     return zipOpenNewFileInZip4_64(file, filename, zipfi, extrafield_local, size_extrafield_local,
         extrafield_global, size_extrafield_global, comment, compression_method, level, raw, windowBits,
@@ -183,7 +183,7 @@ extern int ZEXPORT zipOpenNewFileInZip3(zipFile file, const char *filename, cons
     const void *extrafield_local, uint16_t size_extrafield_local, const void *extrafield_global,
     uint16_t size_extrafield_global, const char *comment, uint16_t compression_method, int level,
     int raw, int windowBits, int memLevel, int strategy, const char *password,
-    ZIP_UNUSED uint32_t crc_for_crypting)
+    uint32_t crc_for_crypting)
 {
     return zipOpenNewFileInZip4_64(file, filename, zipfi, extrafield_local, size_extrafield_local,
         extrafield_global, size_extrafield_global, comment, compression_method, level, raw, windowBits,
@@ -194,7 +194,7 @@ extern int ZEXPORT zipOpenNewFileInZip3_64(zipFile file, const char *filename, c
     const void *extrafield_local, uint16_t size_extrafield_local, const void *extrafield_global,
     uint16_t size_extrafield_global, const char *comment, uint16_t compression_method, int level,
     int raw, int windowBits, int memLevel, int strategy, const char *password,
-    ZIP_UNUSED uint32_t crc_for_crypting, int zip64)
+    uint32_t crc_for_crypting, int zip64)
 {
     return zipOpenNewFileInZip4_64(file, filename, zipfi, extrafield_local, size_extrafield_local,
         extrafield_global, size_extrafield_global, comment, compression_method, level, raw, windowBits,

--- a/mz_os_posix.c
+++ b/mz_os_posix.c
@@ -69,7 +69,6 @@ int32_t mz_posix_get_file_date(const char *path, time_t *modified_date, time_t *
     size_t len = 0;
     int32_t err = MZ_INTERNAL_ERROR;
 
-
     memset(&stat_info, 0, sizeof(stat_info));
 
     if (strcmp(path, "-") != 0)
@@ -108,6 +107,7 @@ int32_t mz_posix_set_file_date(const char *path, time_t modified_date, time_t ac
     ut.actime = accessed_date;
     ut.modtime = modified_date;
     // Creation date not supported
+    (void)creation_date;
 
     if (utime(path, &ut) != 0)
         return MZ_INTERNAL_ERROR;

--- a/mz_strm.c
+++ b/mz_strm.c
@@ -270,7 +270,7 @@ void mz_stream_delete(void **stream)
 
 /***************************************************************************/
 
-mz_stream_vtbl mz_stream_crc32_vtbl = {
+static mz_stream_vtbl mz_stream_crc32_vtbl = {
     mz_stream_crc32_open,
     mz_stream_crc32_is_open,
     mz_stream_crc32_read,
@@ -281,7 +281,8 @@ mz_stream_vtbl mz_stream_crc32_vtbl = {
     mz_stream_crc32_error,
     mz_stream_crc32_create,
     mz_stream_crc32_delete,
-    mz_stream_crc32_get_prop_int64
+    mz_stream_crc32_get_prop_int64,
+    NULL
 };
 
 /***************************************************************************/
@@ -303,6 +304,8 @@ int32_t mz_stream_crc32_open(void *stream, const char *path, int32_t mode)
     mz_stream_crc32 *crc32 = (mz_stream_crc32 *)stream;
     crc32->initialized = 1;
     crc32->value = 0;
+    (void)path;
+    (void)mode;
     return MZ_OK;
 }
 
@@ -434,6 +437,10 @@ typedef struct mz_stream_raw_s {
 
 int32_t mz_stream_raw_open(void *stream, const char *path, int32_t mode)
 {
+    (void)stream;
+    (void)path;
+    (void)mode;
+
     return MZ_OK;
 }
 
@@ -486,6 +493,8 @@ int32_t mz_stream_raw_seek(void *stream, int64_t offset, int32_t origin)
 
 int32_t mz_stream_raw_close(void *stream)
 {
+    (void)stream;
+
     return MZ_OK;
 }
 
@@ -524,7 +533,7 @@ int32_t mz_stream_raw_set_prop_int64(void *stream, int32_t prop, int64_t value)
 
 /***************************************************************************/
 
-mz_stream_vtbl mz_stream_raw_vtbl = {
+static mz_stream_vtbl mz_stream_raw_vtbl = {
     mz_stream_raw_open,
     mz_stream_raw_is_open,
     mz_stream_raw_read,

--- a/mz_strm_aes.c
+++ b/mz_strm_aes.c
@@ -38,7 +38,7 @@
 
 /***************************************************************************/
 
-mz_stream_vtbl mz_stream_aes_vtbl = {
+static mz_stream_vtbl mz_stream_aes_vtbl = {
     mz_stream_aes_open,
     mz_stream_aes_is_open,
     mz_stream_aes_read,
@@ -49,7 +49,8 @@ mz_stream_vtbl mz_stream_aes_vtbl = {
     mz_stream_aes_error,
     mz_stream_aes_create,
     mz_stream_aes_delete,
-    mz_stream_aes_get_prop_int64
+    mz_stream_aes_get_prop_int64,
+    NULL
 };
 
 /***************************************************************************/

--- a/mz_strm_buf.c
+++ b/mz_strm_buf.c
@@ -31,7 +31,7 @@
 
 /***************************************************************************/
 
-mz_stream_vtbl mz_stream_buffered_vtbl = {
+static mz_stream_vtbl mz_stream_buffered_vtbl = {
     mz_stream_buffered_open,
     mz_stream_buffered_is_open,
     mz_stream_buffered_read,
@@ -41,7 +41,9 @@ mz_stream_vtbl mz_stream_buffered_vtbl = {
     mz_stream_buffered_close,
     mz_stream_buffered_error,
     mz_stream_buffered_create,
-    mz_stream_buffered_delete
+    mz_stream_buffered_delete,
+    NULL,
+    NULL
 };
 
 /***************************************************************************/
@@ -221,7 +223,7 @@ int32_t mz_stream_buffered_write(void *stream, const void *buf, int32_t size)
             continue;
         }
 
-        memcpy(buffered->writebuf + buffered->writebuf_pos, (char *)buf + (bytes_to_write - bytes_left_to_write), bytes_to_copy);
+        memcpy(buffered->writebuf + buffered->writebuf_pos, (const char *)buf + (bytes_to_write - bytes_left_to_write), bytes_to_copy);
 
         mz_stream_buffered_print(stream, "write copy [remaining %d write %d:%d len %d]\n",
             bytes_to_copy, bytes_to_write, bytes_left_to_write, buffered->writebuf_len);

--- a/mz_strm_bzip.c
+++ b/mz_strm_bzip.c
@@ -23,7 +23,7 @@
 
 /***************************************************************************/
 
-mz_stream_vtbl mz_stream_bzip_vtbl = {
+static mz_stream_vtbl mz_stream_bzip_vtbl = {
     mz_stream_bzip_open,
     mz_stream_bzip_is_open,
     mz_stream_bzip_read,
@@ -61,6 +61,7 @@ int32_t mz_stream_bzip_open(void *stream, const char *path, int32_t mode)
 {
     mz_stream_bzip *bzip = (mz_stream_bzip *)stream;
 
+    (void)path;
 
     bzip->bzstream.bzalloc = 0;
     bzip->bzstream.bzfree = 0;
@@ -265,11 +266,17 @@ int32_t mz_stream_bzip_write(void *stream, const void *buf, int32_t size)
 
 int64_t mz_stream_bzip_tell(void *stream)
 {
+    (void)stream;
+
     return MZ_STREAM_ERROR;
 }
 
 int32_t mz_stream_bzip_seek(void *stream, int64_t offset, int32_t origin)
 {
+    (void)stream;
+    (void)offset;
+    (void)origin;
+
     return MZ_STREAM_ERROR;
 }
 
@@ -373,4 +380,5 @@ void *mz_stream_bzip_get_interface(void)
 
 extern void bz_internal_error(int errcode)
 {
+    (void)errcode;
 }

--- a/mz_strm_crypt.c
+++ b/mz_strm_crypt.c
@@ -40,7 +40,7 @@
 
 /***************************************************************************/
 
-mz_stream_vtbl mz_stream_crypt_vtbl = {
+static mz_stream_vtbl mz_stream_crypt_vtbl = {
     mz_stream_crypt_open,
     mz_stream_crypt_is_open,
     mz_stream_crypt_read,
@@ -51,7 +51,8 @@ mz_stream_vtbl mz_stream_crypt_vtbl = {
     mz_stream_crypt_error,
     mz_stream_crypt_create,
     mz_stream_crypt_delete,
-    mz_stream_crypt_get_prop_int64
+    mz_stream_crypt_get_prop_int64,
+    NULL
 };
 
 /***************************************************************************/
@@ -213,7 +214,7 @@ int32_t mz_stream_crypt_read(void *stream, void *buf, int32_t size)
 int32_t mz_stream_crypt_write(void *stream, const void *buf, int32_t size)
 {
     mz_stream_crypt *crypt = (mz_stream_crypt *)stream;
-    uint8_t *buf_ptr = (uint8_t *)buf;
+    const uint8_t *buf_ptr = (const uint8_t *)buf;
     uint32_t written = 0;
     uint16_t t = 0;
     int32_t i = 0;

--- a/mz_strm_lzma.c
+++ b/mz_strm_lzma.c
@@ -28,7 +28,7 @@
 
 /***************************************************************************/
 
-mz_stream_vtbl mz_stream_lzma_vtbl = {
+static mz_stream_vtbl mz_stream_lzma_vtbl = {
     mz_stream_lzma_open,
     mz_stream_lzma_is_open,
     mz_stream_lzma_read,
@@ -70,6 +70,8 @@ int32_t mz_stream_lzma_open(void *stream, const char *path, int32_t mode)
     uint32_t size = 0;
     uint8_t major = 0;
     uint8_t minor = 0;
+
+    (void)path;
 
     memset(&opt_lzma, 0, sizeof(opt_lzma));
 
@@ -282,11 +284,17 @@ int32_t mz_stream_lzma_write(void *stream, const void *buf, int32_t size)
 
 int64_t mz_stream_lzma_tell(void *stream)
 {
+    (void)stream;
+
     return MZ_STREAM_ERROR;
 }
 
 int32_t mz_stream_lzma_seek(void *stream, int64_t offset, int32_t origin)
 {
+    (void)stream;
+    (void)offset;
+    (void)origin;
+
     return MZ_STREAM_ERROR;
 }
 

--- a/mz_strm_mem.c
+++ b/mz_strm_mem.c
@@ -28,7 +28,7 @@
 
 /***************************************************************************/
 
-mz_stream_vtbl mz_stream_mem_vtbl = {
+static mz_stream_vtbl mz_stream_mem_vtbl = {
     mz_stream_mem_open,
     mz_stream_mem_is_open,
     mz_stream_mem_read,
@@ -38,7 +38,9 @@ mz_stream_vtbl mz_stream_mem_vtbl = {
     mz_stream_mem_close,
     mz_stream_mem_error,
     mz_stream_mem_create,
-    mz_stream_mem_delete
+    mz_stream_mem_delete,
+    NULL,
+    NULL
 };
 
 /***************************************************************************/
@@ -77,6 +79,7 @@ int32_t mz_stream_mem_open(void *stream, const char *path, int32_t mode)
 {
     mz_stream_mem *mem = (mz_stream_mem *)stream;
 
+    (void)path;
 
     mem->mode = mode;
     mem->limit = 0;
@@ -189,12 +192,16 @@ int32_t mz_stream_mem_seek(void *stream, int64_t offset, int32_t origin)
 
 int32_t mz_stream_mem_close(void *stream)
 {
+    (void)stream;
+
     // We never return errors
     return MZ_OK;
 }
 
 int32_t mz_stream_mem_error(void *stream)
 {
+    (void)stream;
+
     // We never return errors
     return MZ_OK;
 }

--- a/mz_strm_posix.c
+++ b/mz_strm_posix.c
@@ -50,7 +50,7 @@
 
 /***************************************************************************/
 
-mz_stream_vtbl mz_stream_posix_vtbl = {
+static mz_stream_vtbl mz_stream_posix_vtbl = {
     mz_stream_posix_open,
     mz_stream_posix_is_open,
     mz_stream_posix_read,
@@ -60,7 +60,9 @@ mz_stream_vtbl mz_stream_posix_vtbl = {
     mz_stream_posix_close,
     mz_stream_posix_error,
     mz_stream_posix_create,
-    mz_stream_posix_delete
+    mz_stream_posix_delete,
+    NULL,
+    NULL
 };
 
 /***************************************************************************/

--- a/mz_strm_split.c
+++ b/mz_strm_split.c
@@ -29,7 +29,7 @@
 
 /***************************************************************************/
 
-mz_stream_vtbl mz_stream_split_vtbl = {
+static mz_stream_vtbl mz_stream_split_vtbl = {
     mz_stream_split_open,
     mz_stream_split_is_open,
     mz_stream_split_read,

--- a/mz_strm_win32.c
+++ b/mz_strm_win32.c
@@ -40,7 +40,7 @@
 
 /***************************************************************************/
 
-mz_stream_vtbl mz_stream_win32_vtbl = {
+static mz_stream_vtbl mz_stream_win32_vtbl = {
     mz_stream_win32_open,
     mz_stream_win32_is_open,
     mz_stream_win32_read,
@@ -50,7 +50,9 @@ mz_stream_vtbl mz_stream_win32_vtbl = {
     mz_stream_win32_close,
     mz_stream_win32_error,
     mz_stream_win32_create,
-    mz_stream_win32_delete
+    mz_stream_win32_delete,
+    NULL,
+    NULL
 };
 
 /***************************************************************************/

--- a/mz_strm_zlib.c
+++ b/mz_strm_zlib.c
@@ -33,7 +33,7 @@
 
 /***************************************************************************/
 
-mz_stream_vtbl mz_stream_zlib_vtbl = {
+static mz_stream_vtbl mz_stream_zlib_vtbl = {
     mz_stream_zlib_open,
     mz_stream_zlib_is_open,
     mz_stream_zlib_read,
@@ -70,6 +70,7 @@ int32_t mz_stream_zlib_open(void *stream, const char *path, int32_t mode)
 {
     mz_stream_zlib *zlib = (mz_stream_zlib *)stream;
 
+    (void)path;
 
     zlib->zstream.data_type = Z_BINARY;
     zlib->zstream.zalloc = Z_NULL;
@@ -267,11 +268,17 @@ int32_t mz_stream_zlib_write(void *stream, const void *buf, int32_t size)
 
 int64_t mz_stream_zlib_tell(void *stream)
 {
+    (void)stream;
+
     return MZ_STREAM_ERROR;
 }
 
 int32_t mz_stream_zlib_seek(void *stream, int64_t offset, int32_t origin)
 {
+    (void)stream;
+    (void)offset;
+    (void)origin;
+
     return MZ_STREAM_ERROR;
 }
 


### PR DESCRIPTION
- unused parameters
- trivial const stripping cases
- missing NULL initializers from vtbls
- missing static scope for vtbls

Missing newlines at EOF addressed in a separate PR.
It's be nice to replace `ZIP_UNUSED var` and `(void)var`
with a global and non-gcc-specific solution, such as:
```c
   #define MZ_UNUSED(symbol)  (void)symbol
```