### PR TITLE
silence more warnings

### DIFF
--- a/mz.h
+++ b/mz.h
@@ -91,6 +91,15 @@ extern "C" {
 // MZ_UTILITY
 #define MZ_UNUSED(SYMBOL)               ((void)SYMBOL)
 
+#if !defined(_WIN64)
+    #define MZ_PTRUINT  unsigned long
+#elif defined(__GNUC__)
+    #define MZ_PTRUINT  unsigned long long
+#else
+    #define MZ_PTRUINT  unsigned __int64
+#endif
+#define MZ_UNCONST(PTR)                 ((void *)(MZ_PTRUINT)(const void *)(PTR))
+
 #ifndef MZ_CUSTOM_ALLOC
 #define MZ_ALLOC(SIZE)                  (malloc(SIZE))
 #endif

--- a/mz_strm.c
+++ b/mz_strm.c
@@ -173,8 +173,8 @@ int32_t mz_stream_copy(void *target, void *source, int32_t len)
     while (len > 0)
     {
         bytes_to_copy = len;
-        if (bytes_to_copy > sizeof(buf))
-            bytes_to_copy = sizeof(buf);
+        if (bytes_to_copy > (int32_t)sizeof(buf))
+            bytes_to_copy = (int32_t)sizeof(buf);
         read = mz_stream_read(source, buf, bytes_to_copy);
         if (read < 0)
             return MZ_STREAM_ERROR;

--- a/mz_strm_aes.c
+++ b/mz_strm_aes.c
@@ -220,7 +220,7 @@ int32_t mz_stream_aes_write(void *stream, const void *buf, int32_t size)
     mz_stream_aes *aes = (mz_stream_aes *)stream;
     int32_t written = 0;
 
-    if (size > sizeof(aes->buffer))
+    if (size > (int32_t)sizeof(aes->buffer))
         return MZ_STREAM_ERROR;
 
     memcpy(aes->buffer, buf, size);

--- a/mz_strm_buf.c
+++ b/mz_strm_buf.c
@@ -340,7 +340,7 @@ int32_t mz_stream_buffered_close(void *stream)
     int32_t bytes_flushed = 0;
 
     mz_stream_buffered_flush(stream, &bytes_flushed);
-    mz_stream_buffered_print(stream, "close\n");
+    mz_stream_buffered_print(stream, "close [flushed %d]\n", bytes_flushed);
 
     if (buffered->readbuf_hits + buffered->readbuf_misses > 0)
         mz_stream_buffered_print(stream, "read efficency %.02f%%\n",

--- a/mz_strm_bzip.c
+++ b/mz_strm_bzip.c
@@ -135,7 +135,7 @@ int32_t mz_stream_bzip_read(void *stream, void *buf, int32_t size)
             bytes_to_read = sizeof(bzip->buffer);
             if (bzip->max_total_in > 0)
             {
-                if ((bzip->max_total_in - bzip->total_in) < sizeof(bzip->buffer))
+                if ((bzip->max_total_in - bzip->total_in) < (int64_t)sizeof(bzip->buffer))
                     bytes_to_read = (int32_t)(bzip->max_total_in - bzip->total_in);
             }
 
@@ -254,7 +254,7 @@ int32_t mz_stream_bzip_write(void *stream, const void *buf, int32_t size)
     mz_stream_bzip *bzip = (mz_stream_bzip *)stream;
 
 
-    bzip->bzstream.next_in = (char *)buf;
+    bzip->bzstream.next_in = (char *)MZ_UNCONST(buf);
     bzip->bzstream.avail_in = (unsigned int)size;
 
     mz_stream_bzip_compress(stream, BZ_RUN);

--- a/mz_strm_crypt.c
+++ b/mz_strm_crypt.c
@@ -219,7 +219,7 @@ int32_t mz_stream_crypt_write(void *stream, const void *buf, int32_t size)
     uint16_t t = 0;
     int32_t i = 0;
 
-    if (size > sizeof(crypt->buffer))
+    if (size > (int32_t)sizeof(crypt->buffer))
         return MZ_STREAM_ERROR;
 
     for (i = 0; i < size; i++)

--- a/mz_strm_lzma.c
+++ b/mz_strm_lzma.c
@@ -161,7 +161,7 @@ int32_t mz_stream_lzma_read(void *stream, void *buf, int32_t size)
             bytes_to_read = sizeof(lzma->buffer);
             if (lzma->max_total_in > 0)
             {
-                if ((lzma->max_total_in - lzma->total_in) < sizeof(lzma->buffer))
+                if ((lzma->max_total_in - lzma->total_in) < (int64_t)sizeof(lzma->buffer))
                     bytes_to_read = (int32_t)(lzma->max_total_in - lzma->total_in);
             }
 
@@ -272,7 +272,7 @@ int32_t mz_stream_lzma_write(void *stream, const void *buf, int32_t size)
     mz_stream_lzma *lzma = (mz_stream_lzma *)stream;
 
 
-    lzma->lstream.next_in = (uint8_t*)buf;
+    lzma->lstream.next_in = (uint8_t*)MZ_UNCONST(buf);
     lzma->lstream.avail_in = (size_t)size;
 
     mz_stream_lzma_code(stream, LZMA_RUN);

--- a/mz_strm_split.c
+++ b/mz_strm_split.c
@@ -255,7 +255,7 @@ int32_t mz_stream_split_write(void *stream, const void *buf, int32_t size)
     int32_t bytes_avail = 0;
     int32_t number_disk = -1;
     int32_t err = MZ_OK;
-    uint8_t *buf_ptr = (uint8_t *)buf;
+    const uint8_t *buf_ptr = (const uint8_t *)buf;
 
     while (bytes_left > 0)
     {

--- a/mz_strm_zlib.c
+++ b/mz_strm_zlib.c
@@ -139,7 +139,7 @@ int32_t mz_stream_zlib_read(void *stream, void *buf, int32_t size)
             bytes_to_read = sizeof(zlib->buffer);
             if (zlib->max_total_in > 0)
             {
-                if ((zlib->max_total_in - zlib->total_in) < sizeof(zlib->buffer))
+                if ((zlib->max_total_in - zlib->total_in) < (int64_t)sizeof(zlib->buffer))
                     bytes_to_read = (int32_t)(zlib->max_total_in - zlib->total_in);
             }
 
@@ -256,7 +256,7 @@ int32_t mz_stream_zlib_write(void *stream, const void *buf, int32_t size)
     mz_stream_zlib *zlib = (mz_stream_zlib *)stream;
 
 
-    zlib->zstream.next_in = (Bytef*)buf;
+    zlib->zstream.next_in = (Bytef*)MZ_UNCONST(buf);
     zlib->zstream.avail_in = (uInt)size;
 
     mz_stream_zlib_deflate(stream, Z_NO_FLUSH);


### PR DESCRIPTION
These are the remaining ones:
```
mz_compat.c:141:34: warning: cast from 'const char *' to 'char *' drops const qualifier [-Wcast-qual]
    file_info.filename = (char *)filename;
                                 ^
mz_compat.c:144:39: warning: cast from 'const void *' to 'unsigned char *' drops const qualifier [-Wcast-qual]
    file_info.extrafield = (uint8_t *)extrafield_global;
                                      ^
mz_compat.c:147:33: warning: cast from 'const char *' to 'char *' drops const qualifier [-Wcast-qual]
    file_info.comment = (char *)comment;
                                ^
mz_compat.c:213:54: warning: comparison of integers of different signs: 'int32_t' (aka 'int') and 'uint32_t' (aka 'unsigned int') [-Wsign-compare]
    if (mz_zip_entry_write(compat->handle, buf, len) != len)
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^  ~~~
```
The last one needs a deeper fix and it seems to be an actual bug.