### PR TITLE
restore DEF_MEM_LEVEL constant in mz_compat.h

### DIFF
--- a/mz_compat.h
+++ b/mz_compat.h
@@ -22,6 +22,13 @@ extern "C" {
 
 #ifdef HAVE_ZLIB
 #include "zlib.h"
+#ifndef DEF_MEM_LEVEL
+#  if MAX_MEM_LEVEL >= 8
+#    define DEF_MEM_LEVEL 8
+#  else
+#    define DEF_MEM_LEVEL  MAX_MEM_LEVEL
+#  endif
+#endif
 #else
 #define ZEXPORT
 #define MAX_WBITS     (15)


### PR DESCRIPTION
This is defined in zutil.h in zlib, which is a private
header, so it doesn't get defined when #including zlib.h.
Instead if does get defined by minizip1 in zip.h, so
let's keep doing the same here as well.

Ref: https://github.com/madler/zlib/blob/v1.2.11/contrib/minizip/zip.h#L79-L85
Regression since: https://github.com/nmoinvaz/minizip/commit/ea99a46b6d36a11bc3e3eb3a806482d68ab4a991