### PR TITLE
add support for creating zip files in memory via the compatibility API

### DIFF
--- a/mz_compat.c
+++ b/mz_compat.c
@@ -62,6 +62,10 @@ extern zipFile ZEXPORT zipOpen2_64(const void *path, int append, const char **gl
     {
         if (mz_stream_create(&stream, (mz_stream_vtbl *)*pzlib_filefunc_def) == NULL)
             return NULL;
+
+        // Configure a reasonable grow size if the stream is a memory one
+        if (pzlib_filefunc_def == mz_stream_mem_get_interface())
+            mz_stream_mem_set_grow_size(stream, 128 * 1024);
     }
     else
     {
@@ -280,6 +284,53 @@ extern int ZEXPORT zipClose2_64(zipFile file, const char *global_comment, uint16
     MZ_FREE(compat);
 
     return err;
+}
+
+extern void* ZEXPORT zipGetStream_MZ(zipFile file)
+{
+    mz_compat *compat = (mz_compat *)file;
+
+    return (void *)compat->stream;
+}
+
+// Similar to classic zipClose(), but will not destroy internal MZ
+// objects, e.g. allowing to retrieve the memory buffer via zipGetStream_MZ().
+// You must subsequently call zipCloseFree_MZ() to free those objects.
+extern int ZEXPORT zipClosePrepare_MZ(zipFile file, const char *global_comment)
+{
+    return zipClosePrepare2_MZ(file, global_comment, MZ_VERSION_MADEBY);
+}
+
+extern int ZEXPORT zipClosePrepare2_MZ(zipFile file, const char *global_comment, uint16_t version_madeby)
+{
+    mz_compat *compat = (mz_compat *)file;
+    int32_t err = MZ_OK;
+
+    if (compat == NULL)
+        return ZIP_PARAMERROR;
+
+    if (global_comment != NULL)
+        mz_zip_set_comment(compat->handle, global_comment);
+
+    mz_zip_set_version_madeby(compat->handle, version_madeby);
+    err = mz_zip_close(compat->handle);
+
+    return err;
+}
+
+extern int ZEXPORT zipCloseFree_MZ(zipFile file)
+{
+    mz_compat *compat = (mz_compat *)file;
+
+    if (compat->stream != NULL)
+    {
+        mz_stream_close(compat->stream);
+        mz_stream_delete(&compat->stream);
+    }
+
+    MZ_FREE(compat);
+
+    return MZ_OK;
 }
 
 /***************************************************************************/

--- a/mz_compat.h
+++ b/mz_compat.h
@@ -154,6 +154,11 @@ extern int ZEXPORT zipClose(zipFile file, const char *global_comment);
 extern int ZEXPORT zipClose_64(zipFile file, const char *global_comment);
 extern int ZEXPORT zipClose2_64(zipFile file, const char *global_comment, uint16_t version_madeby);
 
+extern void* ZEXPORT zipGetStream_MZ(zipFile file);
+extern int   ZEXPORT zipClosePrepare_MZ(zipFile file, const char *global_comment);
+extern int   ZEXPORT zipClosePrepare2_MZ(zipFile file, const char *global_comment, uint16_t version_madeby);
+extern int   ZEXPORT zipCloseFree_MZ(zipFile file);
+
 /***************************************************************************/
 
 #if defined(STRICTUNZIP) || defined(STRICTZIPUNZIP)

--- a/mz_strm.c
+++ b/mz_strm.c
@@ -266,6 +266,14 @@ void mz_stream_delete(void **stream)
     *stream = NULL;
 }
 
+const void* mz_stream_get_interface(const void *stream)
+{
+    const mz_stream *strm = (const mz_stream *)stream;
+    if (strm == NULL || strm->vtbl == NULL)
+        return MZ_STREAM_ERROR;
+    return strm->vtbl;
+}
+
 /***************************************************************************/
 
 typedef struct mz_stream_raw_s {

--- a/mz_strm.h
+++ b/mz_strm.h
@@ -97,6 +97,8 @@ int32_t mz_stream_set_prop_int64(void *stream, int32_t prop, int64_t value);
 void*   mz_stream_create(void **stream, mz_stream_vtbl *vtbl);
 void    mz_stream_delete(void **stream);
 
+const void* mz_stream_get_interface(const void *stream);
+
 /***************************************************************************/
 
 int32_t mz_stream_raw_open(void *stream, const char *filename, int32_t mode);


### PR DESCRIPTION
This adds 4 new, MZ-specific API calls to the compatibility interface:
```
void* zipGetStream_MZ(zipFile file)
int   zipClosePrepare_MZ(zipFile file, const char *global_comment)
int   zipClosePrepare2_MZ(zipFile file, const char *global_comment, uint16_t version_madeby)
int   zipCloseFree_MZ(zipFile file)
```

It also adds one API call to the native mz interface, making it
possible to query the type of a stream:
```
const void* mz_stream_get_interface(const void *stream)
```