### PR TITLE
fix zipOpenNewFileInZip*() to allow passing level in raw mode

### DIFF
--- a/mz_compat.c
+++ b/mz_compat.c
@@ -185,9 +185,6 @@ extern int ZEXPORT zipOpenNewFileInZip5(zipFile file, const char *filename, cons
         file_info.aes_version = MZ_AES_VERSION;
 #endif
 
-    if (raw)
-        level = 0;
-
     return mz_zip_entry_write_open(compat->handle, &file_info, (int16_t)level, password);
 }
 


### PR DESCRIPTION
This syncs this behaviour with original minizip (as of 1.2.11)

Ref: https://github.com/nmoinvaz/minizip/issues/289#issuecomment-408515522
