### PR TITLE
use system Bzip2 library if available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,16 @@ if(USE_ZLIB)
     add_definitions(-DHAVE_ZLIB)
 endif()
 
+# Check if bzip2 installation is present
+if(USE_BZIP2)
+    set(BZIP2_ROOT ${DEF_BZIP2_ROOT} CACHE PATH "Parent directory of bzip2 installation")
+    find_package(BZip2)
+    if(BZIP2_FOUND)
+        include_directories(${BZIP2_INCLUDE_DIRS})
+    endif()
+    add_definitions(-DHAVE_BZIP2)
+endif()
+
 set(MINIZIP_PC ${CMAKE_CURRENT_BINARY_DIR}/minizip.pc)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/minizip.pc.cmakein ${MINIZIP_PC} @ONLY)
 
@@ -202,7 +212,14 @@ if(USE_ZLIB)
     endif()
 endif()
 
-if(USE_BZIP2)
+if(USE_BZIP2 AND BZIP2_FOUND)
+    add_definitions(-DHAVE_BZIP2)
+
+    list(APPEND MINIZIP_SRC "mz_strm_bzip.c")
+    list(APPEND MINIZIP_PUBLIC_HEADERS "mz_strm_bzip.h")
+
+    set(CMAKE_REQUIRED_LIBRARIES BZip2::BZip2)
+elseif(USE_BZIP2)
     add_definitions(-DHAVE_BZIP2)
     add_definitions(-DBZ_NO_STDIO)
 
@@ -369,6 +386,9 @@ set_target_properties(${PROJECT_NAME} PROPERTIES LINKER_LANGUAGE C PREFIX ""
                       POSITION_INDEPENDENT_CODE 1)
 if(USE_ZLIB)
     target_link_libraries(${PROJECT_NAME} ZLIB::ZLIB)
+endif()
+if(USE_BZIP2 AND BZIP2_FOUND)
+    target_link_libraries(${PROJECT_NAME} BZip2::BZip2)
 endif()
 if(USE_LZMA)
     set_target_properties(${PROJECT_NAME} PROPERTIES C_STANDARD 99)


### PR DESCRIPTION
Checks if BZip2 installation is present and link against the system one if so.

Previous discussion: #296 