### PR TITLE
fix mem_stream leak.

### DIFF
--- a/mz_zip_rw.c
+++ b/mz_zip_rw.c
@@ -890,8 +890,8 @@ int32_t mz_zip_writer_close(void *handle)
 
     if (writer->mem_stream != NULL)
     {
-        mz_stream_mem_close(writer->file_stream);
-        mz_stream_mem_delete(&writer->file_stream);
+        mz_stream_mem_close(writer->mem_stream);
+        mz_stream_mem_delete(&writer->mem_stream);
     }
 
     return err;


### PR DESCRIPTION
writer->mem_stream is leaked when mz_zip_writer_open_file_in_memory is used.
I think this is because mem_stream is not closed at mz_zip_writer_close.