### PR TITLE
Fix: if(<variable|string> LESS_EQUAL <variable|string>)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,7 +122,7 @@ if(UNIX)
     if(ANDROID)
         string(REGEX REPLACE "android-([0-9+])" "\\1"
             android_api "${ANDROID_PLATFORM}")
-        if(${android_api} LESS 24)
+        if(android_api LESS 24)
             set(define_lfs_macros FALSE)
         endif()
     endif()


### PR DESCRIPTION
**Error information:**
-- Could NOT find BZip2 (missing: BZIP2_LIBRARIES BZIP2_INCLUDE_DIR)
CMake Error at CMakeLists.txt:125 (if):
  if given arguments:

    "LESS" "24"

  Unknown arguments specified


-- Configuring incomplete, errors occurred!


**The cmake docments about of if:**

if(<variable|string> LESS_EQUAL <variable|string>)
    True if the given string or variable’s value is a valid number and less than or equal to that on the right.