### PR TITLE
Fix infinite loop if a read operation does not return any bytes

### DIFF
--- a/mz_strm.c
+++ b/mz_strm.c
@@ -182,7 +182,7 @@ int32_t mz_stream_copy(void *target, void *source, int32_t len)
         if (bytes_to_copy > (int32_t)sizeof(buf))
             bytes_to_copy = sizeof(buf);
         read = mz_stream_read(source, buf, bytes_to_copy);
-        if (read < 0)
+        if (read <= 0)
             return MZ_STREAM_ERROR;
         written = mz_stream_write(target, buf, read);
         if (written != read)

--- a/mz_strm_mem.c
+++ b/mz_strm_mem.c
@@ -108,7 +108,7 @@ int32_t mz_stream_mem_read(void *stream, void *buf, int32_t size)
     if (size > mem->size - mem->position)
         size = mem->size - mem->position;
 
-    if (mem->position + size > mem->limit)
+    if ((size == 0) || (mem->position + size > mem->limit))
         return 0;
 
     memcpy(buf, mem->buffer + mem->position, size);


### PR DESCRIPTION
While I was fuzzing a program of mine, I encountered an infinite loop. The input file was obviously malformed, and minizip was trying to copy N bytes from a stream with M bytes (N > M). In that case, the limit is reached and `mz_stream_mem_read` does not return any bytes. That causes an infinite loop in `mz_stream_copy`.