### PR TITLE
enable warnings for gcc/clang, misc minor fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,10 @@ if("${CMAKE_SYSTEM_NAME}" STREQUAL "WindowsStore")
     add_definitions(-DMZ_WINRT_API)
 endif()
 
+if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_CLANG)
+    add_compile_options(-W -Wall)
+endif()
+
 if(UNIX)
     add_compile_options(-O3)
 

--- a/lib/liblzma/check/check.c
+++ b/lib/liblzma/check/check.c
@@ -83,6 +83,8 @@ lzma_check_size(lzma_check type)
 extern void
 lzma_check_init(lzma_check_state *check, lzma_check type)
 {
+	(void)check;
+
 	switch (type) {
 	case LZMA_CHECK_NONE:
 		break;
@@ -117,6 +119,10 @@ extern void
 lzma_check_update(lzma_check_state *check, lzma_check type,
 		const uint8_t *buf, size_t size)
 {
+	(void)check;
+	(void)buf;
+	(void)size;
+
 	switch (type) {
 #ifdef HAVE_CHECK_CRC32
 	case LZMA_CHECK_CRC32:
@@ -147,6 +153,8 @@ lzma_check_update(lzma_check_state *check, lzma_check type,
 extern void
 lzma_check_finish(lzma_check_state *check, lzma_check type)
 {
+	(void)check;
+
 	switch (type) {
 #ifdef HAVE_CHECK_CRC32
 	case LZMA_CHECK_CRC32:

--- a/minizip.c
+++ b/minizip.c
@@ -591,7 +591,7 @@ int main(int argc, const char *argv[])
     else if (do_erase)
     {
         strncpy(tmp_path, path, sizeof(tmp_path) - 1);
-        tmp_path[sizeof(tmp_path) - 1] = '\0';
+        tmp_path[sizeof(tmp_path) - 1] = 0;
         strncat(tmp_path, ".tmp", sizeof(tmp_path) - strlen(tmp_path) - 1);
 
         err = minizip_erase(path, tmp_path, argc - (path_arg + 1), &argv[path_arg + 1]);
@@ -605,7 +605,7 @@ int main(int argc, const char *argv[])
     {
         // Swap zip with temporary zip, backup old zip if possible
         strncpy(bak_path, path, sizeof(bak_path) - 1);
-        bak_path[sizeof(bak_path) - 1] = '\0';
+        bak_path[sizeof(bak_path) - 1] = 0;
         strncat(bak_path, ".bak", sizeof(bak_path) - strlen(bak_path) - 1);
 
         if (mz_os_file_exists(bak_path) == MZ_OK)

--- a/minizip.c
+++ b/minizip.c
@@ -590,7 +590,8 @@ int main(int argc, const char *argv[])
     }
     else if (do_erase)
     {
-        strncpy(tmp_path, path, sizeof(tmp_path));
+        strncpy(tmp_path, path, sizeof(tmp_path) - 1);
+        tmp_path[sizeof(tmp_path) - 1] = '\0';
         strncat(tmp_path, ".tmp", sizeof(tmp_path) - strlen(tmp_path) - 1);
 
         err = minizip_erase(path, tmp_path, argc - (path_arg + 1), &argv[path_arg + 1]);
@@ -603,7 +604,8 @@ int main(int argc, const char *argv[])
     if (err == MZ_OK && do_erase)
     {
         // Swap zip with temporary zip, backup old zip if possible
-        strncpy(bak_path, path, sizeof(bak_path));
+        strncpy(bak_path, path, sizeof(bak_path) - 1);
+        bak_path[sizeof(bak_path) - 1] = '\0';
         strncat(bak_path, ".bak", sizeof(bak_path) - strlen(bak_path) - 1);
 
         if (mz_os_file_exists(bak_path) == MZ_OK)

--- a/minizip.c
+++ b/minizip.c
@@ -101,7 +101,7 @@ int32_t minizip_list(const char *path)
     }
 
     err = mz_zip_reader_goto_first_entry(reader);
-        
+
     if (err != MZ_OK && err != MZ_END_OF_LIST)
     {
         printf("Error %d going to first entry in zip file\n", err);
@@ -278,7 +278,7 @@ int32_t minizip_add(const char *path, const char *password, minizip_opt *options
     {
         printf("Error %d opening zip for writing\n", err);
     }
-    
+
     err_close = mz_zip_writer_close(writer);
     if (err_close != MZ_OK)
     {
@@ -302,7 +302,7 @@ int32_t minizip_extract_progress_cb(void *handle, void *userdata, mz_zip_file *f
 {
     double progress = 0;
     uint8_t raw = 0;
-    
+
     mz_zip_reader_get_raw(handle, &raw);
 
     if (raw && file_info->compressed_size > 0)

--- a/mz_compat.c
+++ b/mz_compat.c
@@ -511,7 +511,7 @@ int ZEXPORT unzGetGlobalComment(unzFile file, char *comment, uint16_t comment_si
     if (err == MZ_OK)
     {
         strncpy(comment, comment_ptr, comment_size - 1);
-        comment[comment_size - 1] = '\0';
+        comment[comment_size - 1] = 0;
     }
     return err;
 }

--- a/mz_compat.c
+++ b/mz_compat.c
@@ -509,7 +509,10 @@ int ZEXPORT unzGetGlobalComment(unzFile file, char *comment, uint16_t comment_si
         return UNZ_PARAMERROR;
     err = mz_zip_get_comment(compat->handle, &comment_ptr);
     if (err == MZ_OK)
-        strncpy(comment, comment_ptr, comment_size);
+    {
+        strncpy(comment, comment_ptr, comment_size - 1);
+        comment[comment_size - 1] = '\0';
+    }
     return err;
 }
 

--- a/mz_compat.c
+++ b/mz_compat.c
@@ -376,7 +376,7 @@ unzFile ZEXPORT unzOpen2_64(const void *path, zlib_filefunc64_def *pzlib_filefun
         if (mz_stream_os_create(&stream) == NULL)
             return NULL;
     }
-    
+
     if (mz_stream_open(stream, path, MZ_OPEN_MODE_READ) != MZ_OK)
     {
         mz_stream_delete(&stream);
@@ -541,7 +541,7 @@ int ZEXPORT unzOpenCurrentFile3(unzFile file, int *method, int *level, int raw, 
             *level = 6;
             switch (file_info->flag & 0x06)
             {
-            case MZ_ZIP_FLAG_DEFLATE_SUPER_FAST: 
+            case MZ_ZIP_FLAG_DEFLATE_SUPER_FAST:
                 *level = 1;
                 break;
             case MZ_ZIP_FLAG_DEFLATE_FAST:

--- a/mz_os.c
+++ b/mz_os.c
@@ -72,7 +72,7 @@ int32_t mz_path_combine(char *path, const char *join, int32_t max_path)
     if (path_len == 0)
     {
         strncpy(path, join, max_path - 1);
-        path[max_path - 1] = '\0';
+        path[max_path - 1] = 0;
     }
     else
     {

--- a/mz_os.c
+++ b/mz_os.c
@@ -71,7 +71,8 @@ int32_t mz_path_combine(char *path, const char *join, int32_t max_path)
 
     if (path_len == 0)
     {
-        strncpy(path, join, max_path);
+        strncpy(path, join, max_path - 1);
+        path[max_path - 1] = '\0';
     }
     else
     {

--- a/mz_os.c
+++ b/mz_os.c
@@ -173,7 +173,7 @@ int32_t mz_path_resolve(const char *path, char *output, int32_t max_output)
 
                 // Remove current directory . if not at end of stirng
                 if ((*check == 0) || (*check == '\\' || *check == '/'))
-                {                   
+                {
                     // Only proceed if .\ is not entire string
                     if (check[1] != 0 || (path != source))
                     {
@@ -204,7 +204,7 @@ int32_t mz_path_resolve(const char *path, char *output, int32_t max_output)
                             }
                             while (target > output);
                         }
-                        
+
                         if ((target == output) && (*source != 0))
                             source += 1;
                         if ((*target == '\\' || *target == '/') && (*source == 0))
@@ -232,14 +232,14 @@ int32_t mz_path_resolve(const char *path, char *output, int32_t max_output)
     return MZ_OK;
 }
 
-int32_t mz_path_remove_filename(const char *path)
+int32_t mz_path_remove_filename(char *path)
 {
     char *path_ptr = NULL;
 
     if (path == NULL)
         return MZ_PARAM_ERROR;
 
-    path_ptr = (char *)(path + strlen(path) - 1);
+    path_ptr = path + strlen(path) - 1;
 
     while (path_ptr > path)
     {
@@ -371,11 +371,10 @@ int32_t mz_encoding_cp437_to_utf8(const char *source, char *target, int32_t max_
     uint32_t utf8_char = 0;
     uint8_t utf8_byte = 0;
     uint8_t cp437_char = 0;
-    int32_t i = 0;
     int32_t x = 0;
     int32_t written = 0;
 
-    // Convert ibm codepage 437 encoding to utf-8 
+    // Convert ibm codepage 437 encoding to utf-8
     while (*source != 0)
     {
         cp437_char = *source;

--- a/mz_os.h
+++ b/mz_os.h
@@ -54,7 +54,7 @@ int32_t mz_path_compare_wc(const char *path, const char *wildcard, uint8_t ignor
 int32_t mz_path_resolve(const char *path, char *target, int32_t max_target);
 // Resolves path
 
-int32_t mz_path_remove_filename(const char *path);
+int32_t mz_path_remove_filename(char *path);
 // Remove the filename from a path
 
 int32_t mz_path_get_filename(const char *path, const char **filename);

--- a/mz_os_posix.c
+++ b/mz_os_posix.c
@@ -158,7 +158,7 @@ int32_t mz_posix_get_file_date(const char *path, time_t *modified_date, time_t *
         // Not all systems allow stat'ing a file with / appended
         len = strlen(path);
         name = (char *)malloc(len + 1);
-        strncpy(name, path, len + 1);
+        strncpy(name, path, len);
         name[len] = 0;
         if (name[len - 1] == '/')
             name[len - 1] = 0;

--- a/mz_os_posix.c
+++ b/mz_os_posix.c
@@ -23,7 +23,9 @@
 #if defined unix || defined __APPLE__
 #  include <unistd.h>
 #  include <utime.h>
-#  define HAVE_ARC4RANDOM_BUF
+#  ifndef HAVE_ARC4RANDOM_BUF
+#    define HAVE_ARC4RANDOM_BUF
+#  endif
 #endif
 #if  defined(HAVE_LIBBSD) && \
     !defined(MZ_ZIP_NO_COMPRESSION) && \

--- a/mz_strm_buf.c
+++ b/mz_strm_buf.c
@@ -140,8 +140,10 @@ int32_t mz_stream_buffered_read(void *stream, void *buf, int32_t size)
     mz_stream_buffered_print(stream, "read [size %ld pos %lld]\n", size, buffered->position);
 
     if (buffered->writebuf_len > 0)
+    {
         mz_stream_buffered_print(stream, "switch from write to read, not yet supported [%lld]\n",
             buffered->position);
+    }
 
     while (bytes_left_to_read > 0)
     {
@@ -357,12 +359,16 @@ int32_t mz_stream_buffered_close(void *stream)
     mz_stream_buffered_print(stream, "close [flushed %d]\n", bytes_flushed);
 
     if (buffered->readbuf_hits + buffered->readbuf_misses > 0)
+    {
         mz_stream_buffered_print(stream, "read efficency %.02f%%\n",
             (buffered->readbuf_hits / ((float)buffered->readbuf_hits + buffered->readbuf_misses)) * 100);
+    }
 
     if (buffered->writebuf_hits + buffered->writebuf_misses > 0)
+    {
         mz_stream_buffered_print(stream, "write efficency %.02f%%\n",
             (buffered->writebuf_hits / ((float)buffered->writebuf_hits + buffered->writebuf_misses)) * 100);
+    }
 
     mz_stream_buffered_reset(buffered);
 

--- a/mz_strm_crc32.c
+++ b/mz_strm_crc32.c
@@ -48,7 +48,7 @@ typedef struct mz_stream_crc32_s {
     int64_t    value;
     int64_t    total_in;
     int64_t    total_out;
-    mz_stream_crc32_update 
+    mz_stream_crc32_update
                update;
 } mz_stream_crc32;
 
@@ -194,10 +194,10 @@ int32_t mz_stream_crc32_get_update_func(mz_stream_crc32_update *update)
     if (update == NULL)
         return MZ_PARAM_ERROR;
 #ifdef HAVE_ZLIB
-    *update = 
+    *update =
         (mz_stream_crc32_update)mz_stream_zlib_get_crc32_update();
 #elif defined(HAVE_LZMA)
-    *update = 
+    *update =
         (mz_stream_crc32_update)mz_stream_lzma_get_crc32_update();
 #else
 #error ZLIB or LZMA required for CRC32

--- a/mz_strm_split.c
+++ b/mz_strm_split.c
@@ -96,7 +96,8 @@ static int32_t mz_stream_split_open_disk(void *stream, int32_t number_disk)
     }
     else
     {
-        strncpy(split->path_disk, split->path_cd, split->path_disk_size);
+        strncpy(split->path_disk, split->path_cd, split->path_disk_size - 1);
+        split->path_disk[split->path_disk_size - 1] = '\0';
     }
 
     // If disk part doesn't exist during reading then return MZ_EXIST_ERROR
@@ -185,7 +186,8 @@ int32_t mz_stream_split_open(void *stream, const char *path, int32_t mode)
     if (split->path_cd == NULL)
         return MZ_MEM_ERROR;
 
-    strncpy(split->path_cd, path, split->path_cd_size);
+    strncpy(split->path_cd, path, split->path_cd_size - 1);
+    split->path_cd[split->path_cd_size - 1] = '\0';
 
     split->path_disk_size = (int32_t)strlen(path) + 10;
     split->path_disk = (char *)MZ_ALLOC(split->path_disk_size);
@@ -196,7 +198,8 @@ int32_t mz_stream_split_open(void *stream, const char *path, int32_t mode)
         return MZ_MEM_ERROR;
     }
 
-    strncpy(split->path_disk, path, split->path_disk_size);
+    strncpy(split->path_disk, path, split->path_disk_size - 1);
+    split->path_disk[split->path_disk_size - 1] = '\0';
 
     if (mode & MZ_OPEN_MODE_WRITE)
     {

--- a/mz_strm_zlib.c
+++ b/mz_strm_zlib.c
@@ -25,7 +25,7 @@
 // Define z_crc_t in zlib 1.2.5 and less or if using zlib-ng
 #if defined(ZLIBNG_VERNUM)
 typedef uint32_t z_crc_t;
-#elif (ZLIB_VERNUM < 0x1270) 
+#elif (ZLIB_VERNUM < 0x1270)
 typedef unsigned long z_crc_t;
 #endif
 

--- a/mz_zip.c
+++ b/mz_zip.c
@@ -643,7 +643,8 @@ int32_t mz_zip_set_comment(void *handle, const char *comment)
     zip->comment = (char *)MZ_ALLOC(comment_size);
     if (zip->comment == NULL)
         return MZ_MEM_ERROR;
-    strncpy(zip->comment, comment, comment_size);
+    strncpy(zip->comment, comment, comment_size - 1);
+    zip->comment[comment_size - 1] = '\0';
     return MZ_OK;
 }
 

--- a/mz_zip.c
+++ b/mz_zip.c
@@ -560,7 +560,7 @@ int32_t mz_zip_open(void *handle, void *stream, int32_t mode)
         // Memory streams used to store variable length file info data
         mz_stream_mem_create(&zip->file_info_stream);
         mz_stream_mem_open(zip->file_info_stream, NULL, MZ_OPEN_MODE_CREATE);
-        
+
         mz_stream_mem_create(&zip->local_file_info_stream);
         mz_stream_mem_open(zip->local_file_info_stream, NULL, MZ_OPEN_MODE_CREATE);
     }
@@ -1461,7 +1461,7 @@ int32_t mz_zip_entry_read_open(void *handle, uint8_t raw, const char *password)
 #ifdef MZ_ZIP_NO_DECOMPRESSION
     if (zip->file_info.compression_method != MZ_COMPRESS_METHOD_STORE)
         err = MZ_SUPPORT_ERROR;
-#endif 
+#endif
     if (err == MZ_OK)
         err = mz_zip_entry_open_int(handle, raw, 0, password);
 
@@ -1473,7 +1473,6 @@ int32_t mz_zip_entry_write_open(void *handle, const mz_zip_file *file_info, int1
     mz_zip *zip = (mz_zip *)handle;
     int64_t disk_number = 0;
     int32_t err = MZ_OK;
-    int32_t len = 0;
 
 #if defined(MZ_ZIP_NO_ENCRYPTION)
     if (password != NULL)

--- a/mz_zip_rw.c
+++ b/mz_zip_rw.c
@@ -475,7 +475,7 @@ int32_t mz_zip_reader_entry_save_file(void *handle, const char *path)
         reader->entry_cb(handle, reader->entry_userdata, reader->file_info, path);
 
     strncpy(directory, path, sizeof(directory) - 1);
-    directory[sizeof(directory) - 1] = '\0';
+    directory[sizeof(directory) - 1] = 0;
     mz_path_remove_filename(directory);
 
     // If it is a directory entry then create a directory instead of writing file
@@ -595,7 +595,7 @@ int32_t mz_zip_reader_save_all(void *handle, const char *destination_dir)
         else
         {
             strncpy(utf8_name, reader->file_info->filename, sizeof(utf8_name) - 1);
-            utf8_name[sizeof(utf8_name) - 1] = '\0';
+            utf8_name[sizeof(utf8_name) - 1] = 0;
         }
 
         err = mz_path_resolve(utf8_name, resolved_name, sizeof(resolved_name));
@@ -1182,7 +1182,7 @@ int32_t mz_zip_writer_add_path(void *handle, const char *path, const char *root_
     if (strrchr(path, '*') != NULL)
     {
         strncpy(path_dir, path, sizeof(path_dir) - 1);
-        path_dir[sizeof(path_dir) - 1] = '\0';
+        path_dir[sizeof(path_dir) - 1] = 0;
         mz_path_remove_filename(path_dir);
         wildcard_ptr = path_dir + strlen(path_dir) + 1;
         root_path = path = path_dir;

--- a/mz_zip_rw.h
+++ b/mz_zip_rw.h
@@ -161,7 +161,7 @@ int32_t mz_zip_writer_entry_open(void *handle, mz_zip_file *file_info);
 // Opens an entry in the zip file for writing
 
 int32_t mz_zip_writer_entry_close(void *handle);
-// Closes entry in zip file 
+// Closes entry in zip file
 
 int32_t mz_zip_writer_entry_write(void *handle, const void *buf, int32_t len);
 // Writes data into entry for zip
@@ -187,7 +187,7 @@ int32_t mz_zip_writer_add_path(void *handle, const char *path, const char *root_
 // Enumerates a directory or pattern and adds entries to the zip
 
 int32_t mz_zip_writer_copy_from_reader(void *handle, void *reader);
-// Adds an entry from a zip reader instance 
+// Adds an entry from a zip reader instance
 
 /***************************************************************************/
 


### PR DESCRIPTION
* enable `-W -Wall` for gcc and clang
* fix `strncpy()` calls that may potentially leave the target buffer without
  a terminating zero byte (in `mz_zip_rw.c`)
* fix warnings
* remove `const` from `mz_path_remove_filename()` parameter,
  the function is writing the passed buffer
* fix pedantic warnings (in `mz_strm_buf.c`):
  `warning: suggest braces around empty body in an ‘if’ statement [-Wempty-body]`
* fix spaces at EOL
* fix a redefinition warning for `HAVE_ARC4RANDOM_BUF` on macOS
