### PR TITLE
Make sure progress_cb is called every second

### DIFF
--- a/mz_zip_rw.c
+++ b/mz_zip_rw.c
@@ -438,7 +438,7 @@ int32_t mz_zip_reader_entry_save(void *handle, void *stream, mz_stream_write_cb 
 
         // Every 1 second lets update the progress 
         current_time = time(NULL);
-        if ((current_time - update_time) > 1)
+        if (current_time > update_time)
         {
             if (reader->progress_cb != NULL)
                 reader->progress_cb(handle, reader->progress_userdata, reader->file_info, current_pos);
@@ -1028,7 +1028,7 @@ int32_t mz_zip_writer_add(void *handle, void *stream, mz_stream_read_cb read_cb)
 
         // Every 1 second lets update the progress 
         current_time = time(NULL);
-        if ((current_time - update_time) > 1)
+        if (current_time > update_time)
         {
             if (writer->progress_cb != NULL)
                 writer->progress_cb(handle, writer->progress_userdata, &writer->file_info, current_pos);


### PR DESCRIPTION
The time comparison was wrong and thus progress_cb was called every
second second instead of every second as intended.