### PR TITLE
Add mz_zip_[reader,writer]_set_progress_interval

### DIFF
--- a/mz_os_posix.h
+++ b/mz_os_posix.h
@@ -45,6 +45,7 @@ struct
 dirent* mz_posix_read_dir(DIR *dir);
 int32_t mz_posix_close_dir(DIR *dir);
 int32_t mz_posix_is_dir(const char *path);
+uint64_t mz_posix_ms_time(void);
 
 /***************************************************************************/
 
@@ -62,6 +63,7 @@ int32_t mz_posix_is_dir(const char *path);
 #define mz_os_read_dir          mz_posix_read_dir
 #define mz_os_close_dir         mz_posix_close_dir
 #define mz_os_is_dir            mz_posix_is_dir
+#define mz_os_ms_time           mz_posix_ms_time
 
 /***************************************************************************/
 

--- a/mz_os_win32.c
+++ b/mz_os_win32.c
@@ -381,3 +381,13 @@ int32_t mz_win32_is_dir(const char *path)
 
     return MZ_EXIST_ERROR;
 }
+
+uint64_t mz_win32_ms_time(void) {
+    SYSTEMTIME system_time;
+    GetSystemTime(&system_time);
+
+    FILETIME file_time;
+    SystemTimeToFileTime(&system_time, &file_time);
+
+    return ((((ULONGLONG) file_time.dwHighDateTime) << 32) + file_time.dwLowDateTime)/10000 - 11644473600000;
+}

--- a/mz_os_win32.h
+++ b/mz_os_win32.h
@@ -46,6 +46,7 @@ struct
 dirent* mz_win32_read_dir(DIR *dir);
 int32_t mz_win32_close_dir(DIR *dir);
 int32_t mz_win32_is_dir(const char *path);
+uint64_t mz_win32_ms_time(void);
 
 /***************************************************************************/
 
@@ -63,6 +64,7 @@ int32_t mz_win32_is_dir(const char *path);
 #define mz_os_read_dir          mz_win32_read_dir
 #define mz_os_close_dir         mz_win32_close_dir
 #define mz_os_is_dir            mz_win32_is_dir
+#define mz_os_ms_time           mz_win32_ms_time
 
 /***************************************************************************/
 

--- a/mz_zip_rw.h
+++ b/mz_zip_rw.h
@@ -119,6 +119,9 @@ void    mz_zip_reader_set_password_cb(void *handle, void *userdata, mz_zip_reade
 void    mz_zip_reader_set_progress_cb(void *handle, void *userdata, mz_zip_reader_progress_cb cb);
 // Callback for extraction progress
 
+void    mz_zip_reader_set_progress_interval(void *handle, uint32_t milliseconds);
+// Let at least milliseconds pass between calls to progress callback
+
 void    mz_zip_reader_set_entry_cb(void *handle, void *userdata, mz_zip_reader_entry_cb cb);
 // Callback for zip file entries
 
@@ -161,7 +164,7 @@ int32_t mz_zip_writer_entry_open(void *handle, mz_zip_file *file_info);
 // Opens an entry in the zip file for writing
 
 int32_t mz_zip_writer_entry_close(void *handle);
-// Closes entry in zip file 
+// Closes entry in zip file
 
 int32_t mz_zip_writer_entry_write(void *handle, const void *buf, int32_t len);
 // Writes data into entry for zip
@@ -187,7 +190,7 @@ int32_t mz_zip_writer_add_path(void *handle, const char *path, const char *root_
 // Enumerates a directory or pattern and adds entries to the zip
 
 int32_t mz_zip_writer_copy_from_reader(void *handle, void *reader);
-// Adds an entry from a zip reader instance 
+// Adds an entry from a zip reader instance
 
 /***************************************************************************/
 
@@ -217,6 +220,9 @@ void    mz_zip_writer_set_password_cb(void *handle, void *userdata, mz_zip_write
 
 void    mz_zip_writer_set_progress_cb(void *handle, void *userdata, mz_zip_writer_progress_cb cb);
 // Callback for compression progress
+
+void    mz_zip_writer_set_progress_interval(void *handle, uint32_t milliseconds);
+// Let at least milliseconds pass between calls to progress callback
 
 void    mz_zip_writer_set_entry_cb(void *handle, void *userdata, mz_zip_writer_entry_cb cb);
 // Callback for zip file entries


### PR DESCRIPTION
With mz_zip_reader_set_progress_interval the user can specify how
often in milliseconds the progress callback should be called. This
makes it possible to make a smoother progress bar when using
minizip from a GUI application.