### PR TITLE
mz_zip_reader_entry_read: remove const from buf parameter

### DIFF
--- a/mz_zip_rw.c
+++ b/mz_zip_rw.c
@@ -338,11 +338,11 @@ int32_t mz_zip_reader_entry_close(void *handle)
     return err;
 }
 
-int32_t mz_zip_reader_entry_read(void *handle, const void *buf, int32_t len)
+int32_t mz_zip_reader_entry_read(void *handle, void *buf, int32_t len)
 {
     mz_zip_reader *reader = (mz_zip_reader *)handle;
     int32_t read = 0;
-    read = mz_zip_entry_read(reader->zip_handle, (void *)buf, len);
+    read = mz_zip_entry_read(reader->zip_handle, buf, len);
     return read;
 }
 

--- a/mz_zip_rw.h
+++ b/mz_zip_rw.h
@@ -64,7 +64,7 @@ int32_t mz_zip_reader_entry_open(void *handle);
 int32_t mz_zip_reader_entry_close(void *handle);
 // Closes an entry
 
-int32_t mz_zip_reader_entry_read(void *handle, const void *buf, int32_t len);
+int32_t mz_zip_reader_entry_read(void *handle, void *buf, int32_t len);
 // Reads and entry after being opened
 
 int32_t mz_zip_reader_entry_get_info(void *handle, mz_zip_file **file_info);


### PR DESCRIPTION
The pointer is passed to a function which expects a non-const pointer, and that function actually fills the buffer with data read from ZIP entries.
