### PR TITLE
Modify  target proerty to minizip in only msvc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -380,7 +380,7 @@ add_library(${PROJECT_NAME}
                 ${BZIP2_SRC} ${BZIP2_PUBLIC_HEADERS}
                 ${LZMA_SRC} ${LZMA_PUBLIC_HEADERS})
 
-if (MINGW AND BUILD_SHARED_LIBS)
+if (MSVC AND BUILD_SHARED_LIBS)
   set_target_properties(${PROJECT_NAME} PROPERTIES ARCHIVE_OUTPUT_NAME "minizip")
 endif ()
 


### PR DESCRIPTION
Only msvc toolchain need minizip.lib . then mingw toolchain need libminizip.lib