### PR TITLE
mz_compat.c: fix warnings

### DIFF
--- a/mz_compat.c
+++ b/mz_compat.c
@@ -32,7 +32,7 @@ typedef struct mz_compat_s {
     void     *handle;
     int64_t  entry_index;
     int64_t  entry_pos;
-    int64_t  total_out;
+    uint64_t total_out;
 } mz_compat;
 
 /***************************************************************************/
@@ -903,7 +903,7 @@ int64_t ZEXPORT unzTell64(unzFile file)
     mz_compat *compat = (mz_compat *)file;
     if (compat == NULL)
         return UNZ_PARAMERROR;
-    return compat->total_out;
+    return (int64_t)compat->total_out;
 }
 
 int ZEXPORT unzSeek(unzFile file, uint32_t offset, int origin)
@@ -915,8 +915,6 @@ int ZEXPORT unzSeek64(unzFile file, uint64_t offset, int origin)
 {
     mz_compat *compat = (mz_compat *)file;
     mz_zip_file *file_info = NULL;
-    uint64_t stream_pos_begin = 0;
-    uint64_t stream_pos_end = 0;
     uint64_t position = 0;
     int32_t err = MZ_OK;
     void *stream = NULL;


### PR DESCRIPTION
- remove unused variables
- fix signedness disagreement:
```
mz_compat.c:961:27: warning: comparison of integers of different signs: 'int64_t' (aka 'long long') and 'uint64_t'
      (aka 'unsigned long long') [-Wsign-compare]
    if (compat->total_out == file_info->uncompressed_size)
        ~~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

This one remains:
```
mz_zip.c:986:57: warning: cast from 'const unsigned char *' to 'void *' drops const qualifier [-Wcast-qual]
        mz_stream_mem_set_buffer(extrafield_ms, (void *)file_info->extrafield, file_info->extrafield_size);
                                                        ^
```
