### PR TITLE
Avoid double free on comment

### DIFF
--- a/mz_zip.c
+++ b/mz_zip.c
@@ -612,7 +612,10 @@ int32_t mz_zip_close(void *handle)
     }
 
     if (zip->comment)
+    {
         MZ_FREE(zip->comment);
+        zip->comment = NULL;
+    }
 
     zip->stream = NULL;
     zip->cd_stream = NULL;


### PR DESCRIPTION
This will prevent the zip context to free multiple times the comment value, if for some reason the close function is called several times.