### PR TITLE
Allow reading > 64k at a time on platforms where zlib supports this

### DIFF
--- a/unzip.c
+++ b/unzip.c
@@ -1298,16 +1298,17 @@ extern int ZEXPORT unzReadCurrentFile(unzFile file, voidp buf, uint32_t len)
         return UNZ_END_OF_LIST_OF_FILE;
     if (len == 0)
         return 0;
-    if (len > UINT16_MAX)
+    // avail_out is uInt, so uint32_t len might allow requesting a larger buffer than zlib can support
+    if (len > UINT_MAX)
         return UNZ_PARAMERROR;
 
     s->pfile_in_zip_read->stream.next_out = (uint8_t*)buf;
-    s->pfile_in_zip_read->stream.avail_out = (uint16_t)len;
+    s->pfile_in_zip_read->stream.avail_out = (uInt)len;
 
     if ((s->pfile_in_zip_read->compression_method == 0) || (s->pfile_in_zip_read->raw))
     {
         if (len > s->pfile_in_zip_read->rest_read_compressed + s->pfile_in_zip_read->stream.avail_in)
-            s->pfile_in_zip_read->stream.avail_out = (uint16_t)s->pfile_in_zip_read->rest_read_compressed +
+            s->pfile_in_zip_read->stream.avail_out = (uInt)s->pfile_in_zip_read->rest_read_compressed +
             s->pfile_in_zip_read->stream.avail_in;
     }
 
@@ -1327,7 +1328,7 @@ extern int ZEXPORT unzReadCurrentFile(unzFile file, voidp buf, uint32_t len)
             if (bytes_not_read > 0)
                 memmove(s->pfile_in_zip_read->read_buffer, s->pfile_in_zip_read->stream.next_in, bytes_not_read);
             if (s->pfile_in_zip_read->rest_read_compressed < bytes_to_read)
-                bytes_to_read = (uint16_t)s->pfile_in_zip_read->rest_read_compressed;
+                bytes_to_read = (uint32_t)s->pfile_in_zip_read->rest_read_compressed;
 
             while (total_bytes_read != bytes_to_read)
             {
@@ -1380,7 +1381,7 @@ extern int ZEXPORT unzReadCurrentFile(unzFile file, voidp buf, uint32_t len)
 
             s->pfile_in_zip_read->rest_read_compressed -= total_bytes_read;
             s->pfile_in_zip_read->stream.next_in = (uint8_t*)s->pfile_in_zip_read->read_buffer;
-            s->pfile_in_zip_read->stream.avail_in = (uint16_t)(bytes_not_read + total_bytes_read);
+            s->pfile_in_zip_read->stream.avail_in = (uInt)(bytes_not_read + total_bytes_read);
         }
 
         if ((s->pfile_in_zip_read->compression_method == 0) || (s->pfile_in_zip_read->raw))


### PR DESCRIPTION
zlib uses uInt (`unsigned int`) for avail_in and avail_out.
This type can be limited to 64k and still conform to ANSI C,
but on most platformsit's bigger.

Remove some unnecessarily-narrow casting and only enforce
the actual limit (UINT_MAX), which might be 64k or might be larger.

This is per the recent discussion at the end of #91 and is essentially a version of the fix for #201 (3064a0e5519ddd360d104b45964c734b2b5ec5cb and 930f9188a5fb39947812d21306c6ae587fbe7c66) for the 1.2 branch