### PR TITLE
make inttypes.h optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -282,21 +282,12 @@ if(USE_COMPAT)
     string(REPLACE "MZ_COMPAT_FILE" "MZ_COMPAT_UNZIP" UNZIP_COMPAT_HEADER ${UNZIP_COMPAT_HEADER})
     file(WRITE "unzip.h" ${UNZIP_COMPAT_HEADER})
     list(APPEND MINIZIP_PUBLIC_HEADERS "unzip.h")
+endif()
 
-    include(CheckIncludeFile)
-    check_include_file(inttypes.h HAVE_INTTYPES_H)
-    if(NOT HAVE_INTTYPES_H)
-        set(COMPAT_INTTYPES "\
-#define PRId16 \"hd\"
-#define PRId32 \"d\"
-#define PRIu32 \"u\"
-#define PRIx32 \"x\"
-#define PRId64 \"lld\"
-#define PRIu64 \"llu\"
-#define PRIx64 \"llx\"
-        ")
-        file(WRITE "inttypes.h" ${COMPAT_INTTYPES})
-    endif()
+include(CheckIncludeFile)
+check_include_file(inttypes.h HAVE_INTTYPES_H)
+if (HAVE_INTTYPES_H)
+    add_definitions(-DHAVE_INTTYPES_H)
 endif()
 
 # Include PKCRYPT

--- a/minizip.c
+++ b/minizip.c
@@ -14,7 +14,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include <inttypes.h>
 #include <time.h>
 
 #include "mz.h"

--- a/mz.h
+++ b/mz.h
@@ -18,6 +18,18 @@ extern "C" {
 
 /***************************************************************************/
 
+#if defined(HAVE_INTTYPES_H)
+#  include <inttypes.h>
+#else
+#  define PRId16 "hd"
+#  define PRId32 "d"
+#  define PRIu32 "u"
+#  define PRIx32 "x"
+#  define PRId64 "lld"
+#  define PRIu64 "llu"
+#  define PRIx64 "llx"
+#endif
+
 // MZ_VERSION
 #define MZ_VERSION                      ("2.7.5")
 

--- a/mz_strm_buf.c
+++ b/mz_strm_buf.c
@@ -14,7 +14,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include <inttypes.h>
 #include <errno.h>
 
 #include "mz.h"

--- a/mz_strm_os_win32.c
+++ b/mz_strm_os_win32.c
@@ -15,7 +15,6 @@
 */
 
 #include <stdlib.h>
-#include <inttypes.h>
 
 #include <windows.h>
 

--- a/mz_strm_split.c
+++ b/mz_strm_split.c
@@ -12,7 +12,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include <inttypes.h>
 
 #include "mz.h"
 #include "mz_os.h"

--- a/mz_zip.c
+++ b/mz_zip.c
@@ -20,7 +20,6 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
-#include <inttypes.h>
 #include <ctype.h>
 #include <time.h>
 #include <limits.h>


### PR DESCRIPTION
`inttypes.h` isn't available in certain environments, but instead of relying on CMake to create a fake local copy, let's handle the matter in the source code, and let it work with any build system. If `HAVE_INTTYPES_H` is defined, `inttypes.h` will be used, otherwise the required values will be defined locally.
