### PR TITLE
Add correct shared library prefix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -599,7 +599,7 @@ set_target_properties(${PROJECT_NAME} PROPERTIES
                         VERSION ${VERSION} 
                         SOVERSION ${SOVERSION}
                         LINKER_LANGUAGE C
-                        PREFIX ""
+                        PREFIX ${CMAKE_SHARED_LIBRARY_PREFIX}
                         DEFINE_SYMBOL "MZ_EXPORTS"
                         POSITION_INDEPENDENT_CODE 1)
 if(MZ_LZMA)


### PR DESCRIPTION
Shared library prefix is missing since the project has been renamed. That causes issues on UNIX systems.