### PR TITLE
fixed issue where install target failed due to the fact that the .pc …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,8 +55,8 @@ set(INSTALL_PKGCONFIG_DIR "${CMAKE_INSTALL_FULL_LIBDIR}/pkgconfig" CACHE PATH "I
 set(INSTALL_CMAKE_DIR "${CMAKE_INSTALL_FULL_LIBDIR}/cmake/minizip" CACHE PATH "Installation directory for cmake files.")
 
 set(MINIZIP_PC ${CMAKE_CURRENT_BINARY_DIR}/minizip.pc)
-if(EXISTS ${MINIZIP_PC}.cmakein)
-    configure_file(${MINIZIP_PC}.cmakein ${MINIZIP_PC} @ONLY)
+if(EXISTS minizip.pc.cmakein)
+    configure_file(minizip.pc.cmakein ${MINIZIP_PC} @ONLY)
 endif()
 
 # Check if zlib installation is present


### PR DESCRIPTION
…was never generated

Hey @nmoinvaz! I like what you did out of my first CMake configuration :)
I think a slight "glitch" with the CMake install target and the package conf file found it's way in your last releases.

At least on my side I'm not able to install successfully anymore due to the fact, that the `minizip.pc.cmakein` is search at the wrong place.

Please check this simple patch and keep up the great work!