### PR TITLE
Fix use after context release

### DIFF
--- a/mz_crypt.c
+++ b/mz_crypt.c
@@ -182,9 +182,11 @@ int32_t  mz_crypt_pbkdf2(uint8_t *password, int32_t password_length, uint8_t *sa
             key[k++] = ux[j++];
     }
 
+    // hmac3 uses the same provider as hmac2,
+    // so it must be deleted before the context is destroyed.
+    mz_crypt_hmac_delete(&hmac3);
     mz_crypt_hmac_delete(&hmac1);
     mz_crypt_hmac_delete(&hmac2);
-    mz_crypt_hmac_delete(&hmac3);
 
     return err;
 }

--- a/mz_crypt.c
+++ b/mz_crypt.c
@@ -182,8 +182,8 @@ int32_t  mz_crypt_pbkdf2(uint8_t *password, int32_t password_length, uint8_t *sa
             key[k++] = ux[j++];
     }
 
-    // hmac3 uses the same provider as hmac2,
-    // so it must be deleted before the context is destroyed.
+    /* hmac3 uses the same provider as hmac2, so it must be deleted 
+       before the context is destroyed. */
     mz_crypt_hmac_delete(&hmac3);
     mz_crypt_hmac_delete(&hmac1);
     mz_crypt_hmac_delete(&hmac2);

--- a/mz_crypt_win32.c
+++ b/mz_crypt_win32.c
@@ -511,12 +511,12 @@ int32_t mz_crypt_hmac_copy(void *src_handle, void *target_handle)
     int32_t result = 0;
     int32_t err = MZ_OK;
 
-	if (target->hash)
-	{
-		CryptDestroyHash(target->hash);
-		target->hash = NULL;
-	}
-	
+    if (target->hash)
+    {
+        CryptDestroyHash(target->hash);
+        target->hash = NULL;
+    }
+
     result = CryptDuplicateHash(source->hash, NULL, 0, &target->hash);
 
     if (!result)

--- a/mz_crypt_win32.c
+++ b/mz_crypt_win32.c
@@ -511,6 +511,12 @@ int32_t mz_crypt_hmac_copy(void *src_handle, void *target_handle)
     int32_t result = 0;
     int32_t err = MZ_OK;
 
+	if (target->hash)
+	{
+		CryptDestroyHash(target->hash);
+		target->hash = NULL;
+	}
+	
     result = CryptDuplicateHash(source->hash, NULL, 0, &target->hash);
 
     if (!result)


### PR DESCRIPTION
Fixes a couple of bugs on windows caught by AppVerifier
- in function `mz_crypt_pbkdf2(..)`, `CryptDeleteHash` was being called after the associated Crypt context was released
  - hmac1 and hmac2 are created using `mz_crypt_hmac_init`, so they each get their own context (provider) from the `CryptAcquireContext(..)` function
  - hmac3 is created using `mz_crypt_hmac_copy`, which creates a duplicate of hmac2's hash, sharing the same context
  - During destruction, hmac1 and hmac2 were being deleted first, followed by hmac3. This meant that the crypt contexts were released first by `CryptReleaseContext`. The subsequent call to `CryptDestroyHash(..)` on hmac3's hash would lead to UB as the associated context has already been released by that point
  - Fix: call `mz_crypt_hmac_delete(..)` on hmac3 first, so that the contexts are cleared at the end after the hashes are destroyed.
- in function `mz_crypt_hmac_copy`, if `target->hash` already contained a hash prior to the function being called, that hash would be overwritten, without `CryptDestroyHash` being called on it.
  - Fix: check if `target->hash` is non-empty in `mz_crypt_hmac_copy` and call `CryptDestroyHash` on it