### PR TITLE
Fix support for creating empty archives

### DIFF
--- a/mz_zip.c
+++ b/mz_zip.c
@@ -1077,7 +1077,7 @@ static int32_t mz_zip_write_cd(void *handle)
     mz_zip_print("Zip - Write cd (disk %"PRId32" entries %"PRId64" offset %"PRId64" size %"PRId64")\n",
         zip->disk_number_with_cd, zip->number_entry, zip->cd_offset, zip->cd_size);
 
-    if (zip->cd_size == 0)
+    if (zip->cd_size == 0 && zip->number_entry > 0)
     {
         // Zip does not contain central directory, open with recovery option
         return MZ_FORMAT_ERROR;


### PR DESCRIPTION
The creation of empty archives (with 0 entries) got broken by https://github.com/nmoinvaz/minizip/commit/64faa259d5acc39b842b2eab4eb5b1568acf3ce0.

We do want a Central Directory, otherwise the file created would be 0 bytes and not a valid zip file.