### PR TITLE
Gitignore for cmake generated folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# cmake generated folders
+Debug/
+CMakeFiles/
+CMakeScripts/
+minizip.build/
+minizip.xcodeproj/
+
+# JetBrains editors
+.idea/


### PR DESCRIPTION
This won't automatically ignore the few generated files at the root of the repo, like `CMakeCache.txt`, but it will help having more visibility on modified source files by ignoring the generated folders.

I've also added `.idea/` (used by AppCode and other JetBrains editors), but if you prefer to stick to cmake stuff, we can remove `.idea/` from the list.