### PR TITLE
Allowing compilation on iOS/tvOS when MZ_ZIP_NO_SIGNING is defined

### DIFF
--- a/mz_crypt_apple.c
+++ b/mz_crypt_apple.c
@@ -404,6 +404,8 @@ void mz_crypt_hmac_delete(void **handle)
 
 /***************************************************************************/
 
+#if !defined(MZ_ZIP_NO_SIGNING)
+
 int32_t mz_crypt_sign(uint8_t *message, int32_t message_size, uint8_t *cert_data, int32_t cert_data_size, 
     const char *cert_pwd, uint8_t **signature, int32_t *signature_size)
 {
@@ -525,3 +527,5 @@ int32_t mz_crypt_sign_verify(uint8_t *message, int32_t message_size, uint8_t *si
     
     return err;
 }
+
+#endif


### PR DESCRIPTION
[CMSDecoder](https://developer.apple.com/documentation/security/cmsdecoder) is only on macOS, not on iOS or tvOS.