### PR TITLE
Fix return of mz_stream_zlib_get_prop_int64() for PROP_COMPRESS_WINDOW

### DIFF
--- a/mz_strm_zlib.c
+++ b/mz_strm_zlib.c
@@ -365,6 +365,7 @@ int32_t mz_stream_zlib_get_prop_int64(void *stream, int32_t prop, int64_t *value
         break;
     case MZ_STREAM_PROP_COMPRESS_WINDOW:
         *value = zlib->window_bits;
+         break;
     default:
         return MZ_EXIST_ERROR;
     }


### PR DESCRIPTION
There's a missing `break;` in the switch/case of `mz_stream_zlib_get_prop_int64()` when prop is `MZ_STREAM_PROP_COMPRESS_WINDOW`, resulting in a `MZ_EXIST_ERROR` return instead of `MZ_OK`.