### PR TITLE
Use memcpy instead of strncpy

### DIFF
--- a/aes/entropy.c
+++ b/aes/entropy.c
@@ -3,6 +3,7 @@
 #else
 #include <sys/stat.h>
 #include <fcntl.h>
+#include <unistd.h>
 #endif
 
 #if defined(__cplusplus)

--- a/ioapi.c
+++ b/ioapi.c
@@ -120,7 +120,7 @@ static voidpf file_build_ioposix(FILE *file, const char *filename)
     ioposix->file = file;
     ioposix->filenameLength = strlen(filename) + 1;
     ioposix->filename = (char*)malloc(ioposix->filenameLength * sizeof(char));
-    strncpy(ioposix->filename, filename, ioposix->filenameLength);
+    memcpy(ioposix->filename, filename, ioposix->filenameLength);
     return (voidpf)ioposix;
 }
 


### PR DESCRIPTION
1. `memcpy` is faster than `strncpy`
2. `strncpy` was depending on the size of the source string, therefore useless in comparison with `strcpy`
3. I was getting a compiler warning for `strncpy` for the above reason.