### PR TITLE
fix Windows-specific compiler error and warnings

### DIFF
--- a/mz_os_win32.c
+++ b/mz_os_win32.c
@@ -556,6 +556,10 @@ int32_t mz_os_make_symlink(const char *path, const char *target_path)
     target_path_wide = mz_os_unicode_string_create(target_path, MZ_ENCODING_UTF8);
     if (target_path_wide != NULL)
     {
+        #ifndef SYMBOLIC_LINK_FLAG_DIRECTORY
+        #define SYMBOLIC_LINK_FLAG_DIRECTORY 0x1
+        #endif
+
         if (mz_path_has_slash(target_path) == MZ_OK)
             flags |= SYMBOLIC_LINK_FLAG_DIRECTORY;
 
@@ -608,7 +612,7 @@ int32_t mz_os_read_symlink(const char *path, char *target_path, int32_t max_targ
     wchar_t *target_path_wide = NULL;
     uint32_t attribs = 0;
     uint8_t buffer[MAXIMUM_REPARSE_DATA_BUFFER_SIZE];
-    int32_t length = 0;
+    DWORD length = 0;
     int32_t target_path_len = 0;
     int32_t target_path_idx = 0;
     int32_t err = MZ_OK;
@@ -651,10 +655,10 @@ int32_t mz_os_read_symlink(const char *path, char *target_path, int32_t max_targ
 
                 if (target_path_utf8)
                 {
-                    strncpy(target_path, target_path_utf8, max_target_path - 1);
+                    strncpy(target_path, (const char *)target_path_utf8, max_target_path - 1);
                     target_path[max_target_path - 1] = 0;
                     /* Ensure directories have slash at the end so we can recreate them later */
-                    if (mz_os_is_dir(target_path_utf8) == MZ_OK)
+                    if (mz_os_is_dir((const char *)target_path_utf8) == MZ_OK)
                         mz_path_append_slash(target_path, max_target_path, MZ_PATH_SLASH_PLATFORM);
                     mz_os_utf8_string_delete(&target_path_utf8);
                 }


### PR DESCRIPTION
Exprienced in a mingw-w64 + clang-9 cross-build environment:
```
mz_os_win32.c:560:22: error: use of undeclared identifier 'SYMBOLIC_LINK_FLAG_DIRECTORY'
            flags |= SYMBOLIC_LINK_FLAG_DIRECTORY;
                     ^
mz_os_win32.c:632:91: warning: incompatible pointer types passing 'int32_t *' (aka 'int *') to parameter of type 'LPDWORD' (aka 'unsigned long *')
      [-Wincompatible-pointer-types]
    if (DeviceIoControl(handle, FSCTL_GET_REPARSE_POINT, NULL, 0, buffer, sizeof(buffer), &length, NULL) == TRUE)
                                                                                          ^~~~~~~
/usr/local/opt/mingw-w64/toolchain-x86_64/x86_64-w64-mingw32/include/ioapiset.h:22:175: note: passing argument to parameter 'lpBytesReturned' here
  WINBASEAPI WINBOOL WINAPI DeviceIoControl (HANDLE hDevice, DWORD dwIoControlCode, LPVOID lpInBuffer, DWORD nInBufferSize, LPVOID lpOutBuffer, DWORD nOutBufferSize, LPDWORD lpBytesReturned, LPOVE...
                                                                                                                                                                              ^
mz_os_win32.c:654:42: warning: passing 'uint8_t *' (aka 'unsigned char *') to parameter of type 'const char *' converts between pointers to integer types with
      different sign [-Wpointer-sign]
                    strncpy(target_path, target_path_utf8, max_target_path - 1);
                                         ^~~~~~~~~~~~~~~~
/usr/local/opt/mingw-w64/toolchain-x86_64/x86_64-w64-mingw32/include/string.h:89:69: note: passing argument to parameter '_Source' here
  char *strncpy(char * __restrict__ _Dest,const char * __restrict__ _Source,size_t _Count) __MINGW_ATTRIB_DEPRECATED_SEC_WARN;
                                                                    ^
mz_os_win32.c:657:38: warning: passing 'uint8_t *' (aka 'unsigned char *') to parameter of type 'const char *' converts between pointers to integer types with
      different sign [-Wpointer-sign]
                    if (mz_os_is_dir(target_path_utf8) == MZ_OK)
                                     ^~~~~~~~~~~~~~~~
mz_os_win32.c:473:34: note: passing argument to parameter 'path' here
int32_t mz_os_is_dir(const char *path)
                                 ^
3 warnings and 1 error generated.
```