### PR TITLE
Specifying the minimum recommended version of cmake

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ the library as version 2 because it had become difficult to maintain and code re
 
 To generate project files for your platform:
 
-1. [Download and install](https://cmake.org/install/) cmake (recommending at least version 3.11).
+1. [Download and install](https://cmake.org/install/) cmake (version 3.11 or later recommended).
 2. Run cmake in the minizip directory.
 
 ```

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ the library as version 2 because it had become difficult to maintain and code re
 
 To generate project files for your platform:
 
-1. [Download and install](https://cmake.org/install/) cmake.
+1. [Download and install](https://cmake.org/install/) cmake (recommending at least version 3.11).
 2. Run cmake in the minizip directory.
 
 ```


### PR DESCRIPTION
This recommendation is to avoid scenarios like #429, especially on macOS.