### PR TITLE
mz_os_win32.c: kernel32.dll is always loaded, so use GetModuleHandleW().

### DIFF
--- a/mz_os_win32.c
+++ b/mz_os_win32.c
@@ -524,10 +524,9 @@ int32_t mz_os_make_symlink(const char *path, const char *target_path)
 {
     typedef BOOLEAN (WINAPI *LPCREATESYMBOLICLINKW)(LPCWSTR, LPCWSTR, DWORD);
     LPCREATESYMBOLICLINKW create_symbolic_link_w = NULL;
-    HMODULE kernel32_mod = 0;
+    HMODULE kernel32_mod = NULL;
     wchar_t *path_wide = NULL;
     wchar_t *target_path_wide = NULL;
-    wchar_t kernel32_path[320];
     uint32_t attribs = 0;
     int32_t target_path_len = 0;
     int32_t err = MZ_OK;
@@ -536,24 +535,19 @@ int32_t mz_os_make_symlink(const char *path, const char *target_path)
     if (path == NULL)
         return MZ_PARAM_ERROR;
 
-    if (GetSystemDirectoryW(kernel32_path, sizeof(kernel32_path)) == 0)
-        return MZ_SUPPORT_ERROR;
-    wcsncat(kernel32_path, L"\\kernel32.dll", sizeof(kernel32_path));
-    kernel32_mod = LoadLibraryW(kernel32_path);
+    kernel32_mod = GetModuleHandleW(L"kernel32.dll");
     if (kernel32_mod == NULL)
         return MZ_SUPPORT_ERROR;
 
     create_symbolic_link_w = (LPCREATESYMBOLICLINKW)GetProcAddress(kernel32_mod, "CreateSymbolicLinkW");
     if (create_symbolic_link_w == NULL)
     {
-        FreeLibrary(kernel32_mod);
         return MZ_SUPPORT_ERROR;
     }
 
     path_wide = mz_os_unicode_string_create(path, MZ_ENCODING_UTF8);
     if (path_wide == NULL)
     {
-        FreeLibrary(kernel32_mod);
         return MZ_PARAM_ERROR;
     }
 
@@ -574,7 +568,6 @@ int32_t mz_os_make_symlink(const char *path, const char *target_path)
     }
 
     mz_os_unicode_string_delete(&path_wide);
-    FreeLibrary(kernel32_mod);
 
     return err;
 }


### PR DESCRIPTION
The kernel32.dll pathname code had two issues:

1. Using sizeof() for wchar_t[]. sizeof() returns the number of bytes, but the wcs*() functions need number of characters, so we end up telling wcsncat() that the buffer is twice as big as it actually is.

2. wcsncat()'s size parameter is supposed to be the *remaining* size in the buffer, not the total size. wcscat_s() should be used instead, since it takes the total size of the buffer.

None of this is actually needed, since kernel32.dll is used by all Windows programs, so it's always loaded in memory.