### PR TITLE
fix build error with zlib-ng compat

### DIFF
--- a/mz_crypt.c
+++ b/mz_crypt.c
@@ -15,7 +15,7 @@
 
 #if defined(HAVE_ZLIB)
 #  include "zlib.h"
-#  if defined(ZLIBNG_VERNUM)
+#  if defined(ZLIBNG_VERNUM) && !defined(ZLIB_COMPAT)
 #    include "zlib-ng.h"
 #  endif
 #elif defined(HAVE_LZMA)

--- a/mz_strm_zlib.c
+++ b/mz_strm_zlib.c
@@ -15,7 +15,7 @@
 #include "mz_strm_zlib.h"
 
 #include "zlib.h"
-#if defined(ZLIBNG_VERNUM)
+#if defined(ZLIBNG_VERNUM) && !defined(ZLIB_COMPAT)
 #  include "zlib-ng.h"
 #endif
 


### PR DESCRIPTION
when build zlib-ng with zlib-compat and ZLIB_COMPAT-ON,
error like this:
/home/minizip/minizip-2.9.1/mz_crypt.c:19:14: fatal error:
-ng.h: No
such file or directory
include "zlib-ng.h"
/home/minizip/minizip-2.9.1/mz_strm_zlib.c:19:12: fatal error:
zlib-ng.h: No such file or directory
include "zlib-ng.h"

Signed-off-by: Chunmei Xu <xuchunmei@linux.alibaba.com>