### PR TITLE
CMakeLists: allow to use minizip as a subproject with add_subdirectory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -685,7 +685,8 @@ elseif(WIN32)
     endif()
 endif()
 
-target_include_directories(${PROJECT_NAME} PUBLIC $<INSTALL_INTERFACE:${INSTALL_INC_DIR}>)
+target_include_directories(${PROJECT_NAME} PUBLIC $<INSTALL_INTERFACE:${INSTALL_INC_DIR}>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 
 # Install files
 if(NOT SKIP_INSTALL_LIBRARIES AND NOT SKIP_INSTALL_ALL)


### PR DESCRIPTION
Hi! 

This adds the build directory to the `target_include_directories` using the BUILD_INTERFACE generator. That way, minizip does not have to be installed when used as a subproject.