### PR TITLE
ignore generated files: zip.h and unzip.h

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+unzip.h
+zip.h


### PR DESCRIPTION
Any objections to starting a .gitignore file? `zip.h` and `unzip.h` are generated by CMake no matter from where it is called. It would be nice to not have a changed repository after every cmake change :)