### PR TITLE
mz_os_utf8_string_create() fix warning with a cast

### DIFF
--- a/mz_os_posix.c
+++ b/mz_os_posix.c
@@ -96,7 +96,7 @@ uint8_t *mz_os_utf8_string_create(const char *string, int32_t encoding)
 
     string_length = strlen(string);
     string_copy = (uint8_t *)MZ_ALLOC((int32_t)(string_length + 1));
-    strncpy(string_copy, string, string_length);
+    strncpy((char *)string_copy, string, string_length);
     string_copy[string_length] = 0;
 
     return string_copy;


### PR DESCRIPTION
```
mz_os_posix.c:99:13: warning: passing 'uint8_t *' (aka 'unsigned char *') to parameter of type 'char *' converts between pointers to
      integer types with different sign [-Wpointer-sign]
    strncpy(string_copy, string, string_length);
            ^~~~~~~~~~~
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/secure/_string.h:128:28: note: expanded from macro 'strncpy'
                __builtin___strncpy_chk (dest, __VA_ARGS__, __darwin_obsz (dest))
                                         ^~~~
```