### PR TITLE
Use __has_include instead of preprocessor defines.

### DIFF
--- a/mz.h
+++ b/mz.h
@@ -158,7 +158,8 @@
 #include <string.h> /* memset, strncpy, strlen */
 #include <limits.h>
 
-#if __has_include(<stdint.h>)
+#if defined(HAVE_STDINT_H) || \
+   (defined(__has_include) && __has_include(<stdint.h>))
 #  include <stdint.h>
 #endif
 
@@ -187,7 +188,8 @@ typedef unsigned int       uint32_t;
 typedef unsigned long long uint64_t;
 #endif
 
-#if __has_include(<inttypes.h>)
+#if defined(HAVE_INTTYPES_H) || \
+   (defined(__has_include) && __has_include(<inttypes.h>))
 #  include <inttypes.h>
 #endif
 

--- a/mz.h
+++ b/mz.h
@@ -158,7 +158,7 @@
 #include <string.h> /* memset, strncpy, strlen */
 #include <limits.h>
 
-#ifdef HAVE_STDINT_H
+#if __has_include(<stdint.h>)
 #  include <stdint.h>
 #endif
 
@@ -187,7 +187,7 @@ typedef unsigned int       uint32_t;
 typedef unsigned long long uint64_t;
 #endif
 
-#ifdef HAVE_INTTYPES_H
+#if __has_include(<inttypes.h>)
 #  include <inttypes.h>
 #endif
 


### PR DESCRIPTION
As [discussed](https://github.com/ZipArchive/ZipArchive/issues/572#issuecomment-634772990) this lets the compiler check for header availability.

I left the checks for `HAVE_STDINT_H` and `HAVE_INTTYPES_H` in CMakeLists, as they still seem to be used in liblzma.