### PR TITLE
CMakeLists.txt: use pkg-config to find openssl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,7 +140,13 @@ endif()
 
 # Check to see if openssl installation is present
 if(MZ_OPENSSL)
-    find_package(OpenSSL)
+    find_package(PkgConfig)
+    if(PKGCONFIG_FOUND)
+        pkg_check_modules(OPENSSL openssl)
+    endif()
+    if(NOT OPENSSL_FOUND)
+        find_package(OpenSSL)
+    endif()
     if (OPENSSL_FOUND)
         message(STATUS "Using OpenSSL ${OPENSSL_VERSION}")
 


### PR DESCRIPTION
Use pkg-config to find openssl libraries otherwise minizip will fail to
retrieve openssl static dependencies such as -latomic and build of
test_cmd will fail on:

```
[100%] Linking C executable test_cmd
/home/test/autobuild/run/instance-3/output-1/host/opt/ext-toolchain/bin/../lib/gcc/sparc-buildroot-linux-uclibc/8.3.0/../../../../sparc-buildroot-linux-uclibc/bin/ld: /home/test/autobuild/run/instance-3/output-1/host/sparc-buildroot-linux-uclibc/sysroot/usr/lib/libcrypto.a(bio_lib.o): in function `BIO_free':
bio_lib.c:(.text+0x510): undefined reference to `__atomic_fetch_sub_4'
```

Fixes:
 - http://autobuild.buildroot.org/results/b54b625751a45d3b449fffcdfaa06fb9209b4652

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>