### PR TITLE
Update zstd magic number to comply with the latest zip specification

### DIFF
--- a/mz.h
+++ b/mz.h
@@ -63,8 +63,7 @@
 #define MZ_COMPRESS_METHOD_DEFLATE      (8)
 #define MZ_COMPRESS_METHOD_BZIP2        (12)
 #define MZ_COMPRESS_METHOD_LZMA         (14)
-#define MZ_COMPRESS_METHOD_ZSTD         (20)
-#define MZ_COMPRESS_METHOD_WZZSTD       (93)
+#define MZ_COMPRESS_METHOD_ZSTD         (93)
 #define MZ_COMPRESS_METHOD_AES          (99)
 
 #define MZ_COMPRESS_LEVEL_DEFAULT       (-1)

--- a/mz_zip.c
+++ b/mz_zip.c
@@ -1621,7 +1621,6 @@ static int32_t mz_zip_entry_open_int(void *handle, uint8_t raw, int16_t compress
 #endif
 #ifdef HAVE_ZSTD
     case MZ_COMPRESS_METHOD_ZSTD:
-    case MZ_COMPRESS_METHOD_WZZSTD:
 #endif
         err = MZ_OK;
         break;
@@ -1708,8 +1707,7 @@ static int32_t mz_zip_entry_open_int(void *handle, uint8_t raw, int16_t compress
             mz_stream_lzma_create(&zip->compress_stream);
 #endif
 #ifdef HAVE_ZSTD
-        else if ((zip->file_info.compression_method == MZ_COMPRESS_METHOD_ZSTD) ||
-                 (zip->file_info.compression_method == MZ_COMPRESS_METHOD_WZZSTD))
+        else if (zip->file_info.compression_method == MZ_COMPRESS_METHOD_ZSTD)
             mz_stream_zstd_create(&zip->compress_stream);
 #endif
         else
@@ -1742,7 +1740,6 @@ static int32_t mz_zip_entry_open_int(void *handle, uint8_t raw, int16_t compress
                 set_end_of_stream = (zip->file_info.flag & MZ_ZIP_FLAG_LZMA_EOS_MARKER);
                 break;
             case MZ_COMPRESS_METHOD_ZSTD:
-            case MZ_COMPRESS_METHOD_WZZSTD:
                 set_end_of_stream = 1;
                 break;
             }


### PR DESCRIPTION
See: https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT

```txt
        0 - The file is stored (no compression)
        1 - The file is Shrunk
        2 - The file is Reduced with compression factor 1
        3 - The file is Reduced with compression factor 2
        4 - The file is Reduced with compression factor 3
        5 - The file is Reduced with compression factor 4
        6 - The file is Imploded
        7 - Reserved for Tokenizing compression algorithm
        8 - The file is Deflated
        9 - Enhanced Deflating using Deflate64(tm)
       10 - PKWARE Data Compression Library Imploding (old IBM TERSE)
       11 - Reserved by PKWARE
       12 - File is compressed using BZIP2 algorithm
       13 - Reserved by PKWARE
       14 - LZMA
       15 - Reserved by PKWARE
       16 - IBM z/OS CMPSC Compression
       17 - Reserved by PKWARE
       18 - File is compressed using IBM TERSE (new)
       19 - IBM LZ77 z Architecture 
       20 - deprecated (use method 93 for zstd)
       93 - Zstandard (zstd) Compression 
       94 - MP3 Compression 
       95 - XZ Compression 
       96 - JPEG variant
       97 - WavPack compressed data
       98 - PPMd version I, Rev 1
       99 - AE-x encryption marker (see APPENDIX E)

```