### PR TITLE
Restore Windows deploy in workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -163,6 +163,8 @@ jobs:
           - name: Windows MSVC
             os: windows-latest
             compiler: cl
+            deploy: true	
+            deploy-name: windows
 
           - name: Windows GCC
             os: windows-latest


### PR DESCRIPTION
Hi.
I noticed the that the windows package is missing in the lastest release [2.10.0](https://github.com/nmoinvaz/minizip/releases/tag/2.10.0) due to [this commit](https://github.com/nmoinvaz/minizip/commit/4e0bc12f94ea8487041c2ac79c524e4d242ec46b), so I re-added the deploy settings to Windows MSVC job