### PR TITLE
mz.h: fix build with gcc 4.8

### DIFF
--- a/mz.h
+++ b/mz.h
@@ -158,9 +158,12 @@
 #include <string.h> /* memset, strncpy, strlen */
 #include <limits.h>
 
-#if defined(HAVE_STDINT_H) || \
-   (defined(__has_include) && __has_include(<stdint.h>))
+#if defined(HAVE_STDINT_H)
 #  include <stdint.h>
+#elif defined(__has_include)
+#  if __has_include(<stdint.h>)
+#    include <stdint.h>
+#  endif
 #endif
 
 #ifndef __INT8_TYPE__
@@ -188,9 +191,12 @@ typedef unsigned int       uint32_t;
 typedef unsigned long long uint64_t;
 #endif
 
-#if defined(HAVE_INTTYPES_H) || \
-   (defined(__has_include) && __has_include(<inttypes.h>))
+#if defined(HAVE_INTTYPES_H)
 #  include <inttypes.h>
+#elif defined(__has_include)
+#  if __has_include(<inttypes.h>)
+#    include <inttypes.h>
+#  endif
 #endif
 
 #ifndef PRId8


### PR DESCRIPTION
gcc 4.8 does not support __has_include directive as a result the build
will fail on:

```
/home/naourr/work/instance-1/output-1/build/minizip-2.10.0/mz.h:162:44: error: missing binary operator before token "("
    (defined(__has_include) && __has_include(<stdint.h>))
                                            ^
```

Fix it by appling:
https://gcc.gnu.org/onlinedocs/gcc-10.1.0/cpp/_005f_005fhas_005finclude.html

Fix #510

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>