### PR TITLE
Guard the usage of __has_include behind the defined check

### DIFF
--- a/mz.h
+++ b/mz.h
@@ -158,9 +158,13 @@
 #include <string.h> /* memset, strncpy, strlen */
 #include <limits.h>
 
-#if defined(HAVE_STDINT_H) || \
-   (defined(__has_include) && __has_include(<stdint.h>))
+#if defined(HAVE_STDINT_H)
 #  include <stdint.h>
+#endif
+#if defined(__has_include)
+#if __has_include(<stdint.h>)
+#  include <stdint.h>
+#endif
 #endif
 
 #ifndef __INT8_TYPE__
@@ -188,9 +192,13 @@ typedef unsigned int       uint32_t;
 typedef unsigned long long uint64_t;
 #endif
 
-#if defined(HAVE_INTTYPES_H) || \
-   (defined(__has_include) && __has_include(<inttypes.h>))
+#if defined(HAVE_INTTYPES_H)
 #  include <inttypes.h>
+#endif
+#if defined(__has_include)
+#if __has_include(<inttypes.h>)
+#  include <inttypes.h>
+#endif
 #endif
 
 #ifndef PRId8


### PR DESCRIPTION
According to the gcc [doc](https://gcc.gnu.org/onlinedocs/cpp/_005f_005fhas_005finclude.html), compilers who do not support __hash_include evaluate the makro anyway, ignoring the is defined check.

Tried to compile the conan [recipe](https://github.com/conan-io/conan-center-index/pull/2415) with this profile

[settings]
arch=x86_64
arch_build=x86_64
build_type=Debug
compiler=Visual Studio
compiler.runtime=MTd
compiler.version=14
os=Windows
os_build=Windows
[options]
minizip:shared=False