### PR TITLE
remove lseek64 on Android

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,7 +129,7 @@ if(MZ_ZSTD)
         message(STATUS "Fetching ZSTD ${ZSTD_REPOSITORY}")
 
         if(${CMAKE_VERSION} VERSION_LESS "3.11")
-            message(FATAL_ERROR "CMake 3.11 required to fetch zlib")
+            message(FATAL_ERROR "CMake 3.11 required to fetch zstd")
         else()
             include(FetchContent)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -792,19 +792,19 @@ if(NOT SKIP_INSTALL_LIBRARIES AND NOT SKIP_INSTALL_ALL)
 
     # Create and install CMake package config version file to allow find_package()
     include(CMakePackageConfigHelpers)
-    write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/minizipConfigVersion.cmake
+    write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/minizip-config-version.cmake
         COMPATIBILITY SameMajorVersion)
 
-    file(WRITE minizipConfig.cmake.in "@PACKAGE_INIT@")
+    file(WRITE minizip-config.cmake.in "@PACKAGE_INIT@")
 
     # Create config for find_package()
-    configure_package_config_file(minizipConfig.cmake.in minizipConfig.cmake
+    configure_package_config_file(minizip-config.cmake.in minizip-config.cmake
         INSTALL_DESTINATION "${INSTALL_CMAKE_DIR}")
 
-    file(REMOVE minizipConfig.cmake.in)
+    file(REMOVE minizip-config.cmake.in)
 
-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/minizipConfigVersion.cmake
-                  ${CMAKE_CURRENT_BINARY_DIR}/minizipConfig.cmake
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/minizip-config-version.cmake
+                  ${CMAKE_CURRENT_BINARY_DIR}/minizip-config.cmake
             DESTINATION "${INSTALL_CMAKE_DIR}")
 endif()
 if(NOT SKIP_INSTALL_HEADERS AND NOT SKIP_INSTALL_ALL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -801,6 +801,8 @@ if(NOT SKIP_INSTALL_LIBRARIES AND NOT SKIP_INSTALL_ALL)
     configure_package_config_file(minizipConfig.cmake.in minizipConfig.cmake
         INSTALL_DESTINATION "${INSTALL_CMAKE_DIR}")
 
+    file(REMOVE minizipConfig.cmake.in)
+
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/minizipConfigVersion.cmake
                   ${CMAKE_CURRENT_BINARY_DIR}/minizipConfig.cmake
             DESTINATION "${INSTALL_CMAKE_DIR}")

--- a/README.md
+++ b/README.md
@@ -111,4 +111,4 @@ Thanks go out to all the people who have taken the time to contribute code revie
 
 Thanks to [Gilles Vollant](https://www.winimage.com/zLibDll/minizip.html) on which this work is originally based on.
 
-The [ZIP format](https://github.com/nmoinvaz/minizip/blob/master/doc/appnote.txt) was defined by Phil Katz of PKWARE.
+The [ZIP format](https://github.com/nmoinvaz/minizip/blob/master/doc/zip/appnote.txt) was defined by Phil Katz of PKWARE.

--- a/doc/mz_zip_rw.md
+++ b/doc/mz_zip_rw.md
@@ -42,6 +42,7 @@ The _mz_zip_reader_ and _mz_zip_writer_ objects allows you to easily extract or 
   - [mz_zip_reader_get_raw](#mz_zip_reader_get_raw)
   - [mz_zip_reader_get_zip_cd](#mz_zip_reader_get_zip_cd)
   - [mz_zip_reader_get_comment](#mz_zip_reader_get_comment)
+  - [mz_zip_reader_set_recover](#mz_zip_reader_set_recover)
   - [mz_zip_reader_set_encoding](#mz_zip_reader_set_encoding)
   - [mz_zip_reader_set_sign_required](#mz_zip_reader_set_sign_required)
   - [mz_zip_reader_set_overwrite_cb](#mz_zip_reader_set_overwrite_cb)
@@ -974,6 +975,26 @@ const char *global_comment = NULL;
 if (mz_zip_reader_get_comment(zip_reader, &global_comment) == MZ_OK) {
     printf("Zip comment: %s\n", global_comment);
 }
+```
+
+### mz_zip_reader_set_recover
+
+Sets the ability to recover the central dir by reading local file headers.
+
+**Arguments**
+|Type|Name|Description|
+|-|-|-|
+|void *|handle|_mz_zip_reader_ instance|
+|uint8_t|recover|Set to 1 if recover method is supported, 0 otherwise.|
+
+**Return**
+|Type|Description|
+|-|-|
+|void|No return|
+
+**Example**
+```
+mz_zip_reader_set_recover(zip_reader, 1);
 ```
 
 ### mz_zip_reader_set_encoding

--- a/mz.h
+++ b/mz.h
@@ -158,9 +158,12 @@
 #include <string.h> /* memset, strncpy, strlen */
 #include <limits.h>
 
-#if defined(HAVE_STDINT_H) || \
-   (defined(__has_include) && __has_include(<stdint.h>))
+#if defined(HAVE_STDINT_H)
 #  include <stdint.h>
+#elif defined(__has_include)
+#  if __has_include(<stdint.h>)
+#    include <stdint.h>
+#  endif
 #endif
 
 #ifndef __INT8_TYPE__
@@ -188,9 +191,12 @@ typedef unsigned int       uint32_t;
 typedef unsigned long long uint64_t;
 #endif
 
-#if defined(HAVE_INTTYPES_H) || \
-   (defined(__has_include) && __has_include(<inttypes.h>))
+#if defined(HAVE_INTTYPES_H)
 #  include <inttypes.h>
+#elif defined(__has_include)
+#  if __has_include(<inttypes.h>)
+#    include <inttypes.h>
+#  endif
 #endif
 
 #ifndef PRId8

--- a/mz_strm_bzip.c
+++ b/mz_strm_bzip.c
@@ -4,7 +4,7 @@
    Copyright (C) 2010-2020 Nathan Moinvaziri
       https://github.com/nmoinvaz/minizip
 
-   This program is distributed under the terms of the same license as bzip.
+   This program is distributed under the terms of the same license as zlib.
    See the accompanying LICENSE file for the full text of the license.
 */
 

--- a/mz_strm_lzma.c
+++ b/mz_strm_lzma.c
@@ -4,7 +4,7 @@
    Copyright (C) 2010-2020 Nathan Moinvaziri
       https://github.com/nmoinvaz/minizip
 
-   This program is distributed under the terms of the same license as lzma.
+   This program is distributed under the terms of the same license as zlib.
    See the accompanying LICENSE file for the full text of the license.
 */
 

--- a/mz_strm_os_posix.c
+++ b/mz_strm_os_posix.c
@@ -32,12 +32,6 @@
 #    define ftello64 _ftelli64
 #    define fseeko64 _fseeki64
 #  endif
-#else
-#  if defined(__ANDROID_API__) && (__ANDROID_API__ < 21)
-#    include <unistd.h>
-#    define fseeko64(s,o,w) \
-        (lseek64(fileno(s),o,w) >= 0 ? 0 : -1)
-#  endif
 #endif
 #ifndef ftello64
 #  define ftello64 ftell

--- a/mz_zip.c
+++ b/mz_zip.c
@@ -1224,7 +1224,7 @@ static int32_t mz_zip_recover_cd(void *handle) {
             mz_stream_seek(zip->stream, local_file_info.compressed_size, MZ_SEEK_CUR);
         }
 
-        while (1) {
+        for (;;) {
             /* Search for the next local header */
             err = mz_stream_find(zip->stream, (const void *)local_header_magic, sizeof(local_header_magic),
                     INT64_MAX, &next_header_pos);
@@ -1267,6 +1267,8 @@ static int32_t mz_zip_recover_cd(void *handle) {
                     }
 
                     compressed_end_pos = descriptor_pos;
+                } else if (eof) {
+                    compressed_end_pos = next_header_pos;
                 } else if (local_file_info.flag & MZ_ZIP_FLAG_DATA_DESCRIPTOR) {
                     /* Wrong local file entry found, keep searching */
                     next_header_pos += 1;

--- a/mz_zip.h
+++ b/mz_zip.h
@@ -74,19 +74,19 @@ int32_t mz_zip_get_comment(void *handle, const char **comment);
 /* Get a pointer to the global comment */
 
 int32_t mz_zip_set_comment(void *handle, const char *comment);
-/* Set the global comment used for writing zip file */
+/* Sets the global comment used for writing zip file */
 
 int32_t mz_zip_get_version_madeby(void *handle, uint16_t *version_madeby);
 /* Get the version made by */
 
 int32_t mz_zip_set_version_madeby(void *handle, uint16_t version_madeby);
-/* Set the version made by used for writing zip file */
+/* Sets the version made by used for writing zip file */
 
 int32_t mz_zip_set_recover(void *handle, uint8_t recover);
-/* Set the ability to recover the central dir by reading local file headers */
+/* Sets the ability to recover the central dir by reading local file headers */
 
 int32_t mz_zip_set_data_descriptor(void *handle, uint8_t data_descriptor);
-/* Set the use of data descriptor flag when writing zip entries */
+/* Sets the use of data descriptor flag when writing zip entries */
 
 int32_t mz_zip_get_stream(void *handle, void **stream);
 /* Get a pointer to the stream used to open */

--- a/mz_zip_rw.c
+++ b/mz_zip_rw.c
@@ -62,6 +62,7 @@ typedef struct mz_zip_reader_s {
     uint8_t     cd_verified;
     uint8_t     cd_zipped;
     uint8_t     entry_verified;
+    uint8_t     recover;
 } mz_zip_reader;
 
 /***************************************************************************/
@@ -83,7 +84,7 @@ int32_t mz_zip_reader_open(void *handle, void *stream) {
     reader->cd_zipped = 0;
 
     mz_zip_create(&reader->zip_handle);
-    mz_zip_set_recover(reader->zip_handle, 1);
+    mz_zip_set_recover(reader->zip_handle, reader->recover);
 
     err = mz_zip_open(reader->zip_handle, stream, MZ_OPEN_MODE_READ);
 
@@ -906,6 +907,14 @@ int32_t mz_zip_reader_get_comment(void *handle, const char **comment) {
     return mz_zip_get_comment(reader->zip_handle, comment);
 }
 
+int32_t mz_zip_reader_set_recover(void *handle, uint8_t recover) {
+    mz_zip_reader *reader = (mz_zip_reader *)handle;
+    if (reader == NULL)
+        return MZ_PARAM_ERROR;
+    reader->recover = recover;
+    return MZ_OK;
+}
+
 void mz_zip_reader_set_encoding(void *handle, int32_t encoding) {
     mz_zip_reader *reader = (mz_zip_reader *)handle;
     reader->encoding = encoding;
@@ -963,6 +972,7 @@ void *mz_zip_reader_create(void **handle) {
     reader = (mz_zip_reader *)MZ_ALLOC(sizeof(mz_zip_reader));
     if (reader != NULL) {
         memset(reader, 0, sizeof(mz_zip_reader));
+        reader->recover = 1;
         reader->progress_cb_interval_ms = MZ_DEFAULT_PROGRESS_INTERVAL;
         *handle = reader;
     }

--- a/mz_zip_rw.h
+++ b/mz_zip_rw.h
@@ -125,6 +125,9 @@ int32_t mz_zip_reader_get_zip_cd(void *handle, uint8_t *zip_cd);
 int32_t mz_zip_reader_get_comment(void *handle, const char **comment);
 /* Gets the comment for the central directory */
 
+int32_t mz_zip_reader_set_recover(void *handle, uint8_t recover);
+/* Sets the ability to recover the central dir by reading local file headers */
+
 void    mz_zip_reader_set_encoding(void *handle, int32_t encoding);
 /* Sets whether or not it should support a special character encoding in zip file names. */
 


### PR DESCRIPTION
the correct usage minizip on Android should be as below.
when api level >= 24, use default config.
when api level < 24, set MZ_FILE32_API=ON to avoid using fseeko/ftello