### PR TITLE
Support building for midipix and LibreSSL 2.7.0+

### DIFF
--- a/mz_crypt_openssl.c
+++ b/mz_crypt_openssl.c
@@ -293,7 +293,7 @@ typedef struct mz_crypt_hmac_s {
 
 /***************************************************************************/
 
-#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || defined(LIBRESSL_VERSION_NUMBER)
+#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || (defined(LIBRESSL_VERSION_NUMBER) && (LIBRESSL_VERSION_NUMBER < 0x2070000fL))
 static HMAC_CTX *HMAC_CTX_new(void) {
     HMAC_CTX *ctx = OPENSSL_malloc(sizeof(HMAC_CTX));
     if (ctx != NULL)

--- a/mz_os.h
+++ b/mz_os.h
@@ -21,10 +21,10 @@ extern "C" {
 #  define MZ_VERSION_MADEBY_HOST_SYSTEM (MZ_HOST_SYSTEM_OSX_DARWIN)
 #elif defined(__riscos__)
 #  define MZ_VERSION_MADEBY_HOST_SYSTEM (MZ_HOST_SYSTEM_RISCOS)
-#elif defined(__unix__)
-#  define MZ_VERSION_MADEBY_HOST_SYSTEM (MZ_HOST_SYSTEM_UNIX)
 #elif defined(_WIN32)
 #  define MZ_VERSION_MADEBY_HOST_SYSTEM (MZ_HOST_SYSTEM_WINDOWS_NTFS)
+#else
+#  define MZ_VERSION_MADEBY_HOST_SYSTEM (MZ_HOST_SYSTEM_UNIX)
 #endif
 
 #if defined(HAVE_LZMA) || defined(HAVE_LIBCOMP)

--- a/mz_os_posix.c
+++ b/mz_os_posix.c
@@ -21,7 +21,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
-#if defined(__APPLE__) || defined(__unix__) || defined(__riscos__)
+#ifndef _WIN32
 #  include <utime.h>
 #  include <unistd.h>
 #endif


### PR DESCRIPTION
midipix is a POSIX layer like cygwin for windows.


LibreSSL 2.7.0 and above has added the HMAC_CTX_{new,free,reset} functions.