### PR TITLE
mz_zip_rw.c - fix potential null dereference in create functions

### DIFF
--- a/mz_zip_rw.c
+++ b/mz_zip_rw.c
@@ -974,8 +974,9 @@ void *mz_zip_reader_create(void **handle) {
         memset(reader, 0, sizeof(mz_zip_reader));
         reader->recover = 1;
         reader->progress_cb_interval_ms = MZ_DEFAULT_PROGRESS_INTERVAL;
-        *handle = reader;
     }
+    if (handle != NULL)
+        *handle = reader;
 
     return reader;
 }
@@ -1905,9 +1906,9 @@ void *mz_zip_writer_create(void **handle) {
 #endif
         writer->compress_level = MZ_COMPRESS_LEVEL_BEST;
         writer->progress_cb_interval_ms = MZ_DEFAULT_PROGRESS_INTERVAL;
-
-        *handle = writer;
     }
+    if (handle != NULL)
+        *handle = writer;
 
     return writer;
 }


### PR DESCRIPTION
In contrast to other mz_*_create() functions, mz_zip_reader_create and mz_zip_writer_create crash on a null argument. This fixes it.