### PR TITLE
CMakeLists.txt - fix zconf.h not being found in case of out-of-source…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,7 +177,7 @@ elseif(MZ_ZLIB)
         clone_repo(ZLIB https://github.com/madler/zlib)
 
         # Don't automatically add all targets to the solution
-        add_subdirectory(${ZLIB_SOURCE_DIR} ${ZLIB_BINARY_DIR} EXCLUDE_FROM_ALL)
+        add_subdirectory(${ZLIB_SOURCE_DIR} ${ZLIB_SOURCE_DIR} EXCLUDE_FROM_ALL)
 
         list(APPEND MINIZIP_INC ${ZLIB_SOURCE_DIR})
         # Have to add zlib to install targets


### PR DESCRIPTION
…-tree build

zlib CMakeLists.txt does some strange things with zconf.h.in and zconf.h
To make sure zconf.h is found with an out-of-source-tree build, we have to adjust the add_subdirectory call, and give the source directory as binary directory.

ZLIB_BINARY_DIR is empty anyways, but that is caused by another issue in the clone_repo cmake helper, and even if it would have a valid value, for zlib we need to point to the source dir.