### PR TITLE
CMakeLists.txt - Introduce MZ_ICONV

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ option(MZ_LIBCOMP "Enables Apple compression" OFF)
 option(MZ_OPENSSL "Enables OpenSSL for encryption" OFF)
 option(MZ_LIBBSD "Enable libbsd crypto random" ON)
 option(MZ_BRG "Enables Brian Gladman's encryption library" OFF)
+option(MZ_ICONV "Enables iconv for string encoding conversion" ON)
 option(MZ_SIGNING "Enables zip signing support" ON)
 option(MZ_COMPRESS_ONLY "Only support compression" OFF)
 option(MZ_DECOMPRESS_ONLY "Only support decompression" OFF)
@@ -392,7 +393,10 @@ if(UNIX)
 
     # Iconv is only necessary when it is not already built-in
     # FindIconv requires cmake 3.11 or higher
-    find_package(Iconv QUIET)
+    if (MZ_ICONV)
+        find_package(Iconv QUIET)
+    endif()
+
     if(Iconv_FOUND)
         message(STATUS "Using Iconv")
 
@@ -405,7 +409,7 @@ if(UNIX)
 
         set(PC_PRIVATE_LIBS "${PC_PRIVATE_LIBS} -liconv")
     else()
-        message(WARNING "Limited encoding support due to missing iconv")
+        message(WARNING "Limited encoding support due to disabled or missing iconv")
     endif()
 endif()
 
@@ -898,6 +902,7 @@ add_feature_info(MZ_LIBCOMP MZ_LIBCOMP "Enables Apple compression")
 add_feature_info(MZ_OPENSSL MZ_OPENSSL "Enables OpenSSL for encryption")
 add_feature_info(MZ_LIBBSD MZ_LIBBSD "Build with libbsd for crypto random")
 add_feature_info(MZ_BRG MZ_BRG "Enables Brian Gladman's encryption library")
+add_feature_info(MZ_ICONV MZ_ICONV "Enables iconv string encoding conversion library")
 add_feature_info(MZ_SIGNING MZ_SIGNING "Enables zip signing support")
 add_feature_info(MZ_COMPRESS_ONLY MZ_COMPRESS_ONLY "Only support compression")
 add_feature_info(MZ_DECOMPRESS_ONLY MZ_DECOMPRESS_ONLY "Only support decompression")

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ cmake --build .
 | MZ_OPENSSL         | Enables OpenSSL encryption            |      OFF      |
 | MZ_LIBBSD          | Builds with libbsd crypto random      |      ON       |
 | MZ_BRG             | Enables Brian Gladman's library       |      OFF      |
+| MZ_ICONV           | Enables iconv encoding conversion     |      ON       |
 | MZ_SIGNING         | Enables zip signing support           |      ON       |
 | MZ_COMPRESS_ONLY   | Only support compression              |      OFF      |
 | MZ_DECOMPRESS_ONLY | Only support decompression            |      OFF      |


### PR DESCRIPTION
This adds an additional CMake option, that allows the user to disable iconv. We support non-Windows systems that have iconv, but we don't want to use it on that system, so adding this switch has been proven to be quite useful.