### PR TITLE
Bugfix/uwp build

### DIFF
--- a/mz_os_win32.c
+++ b/mz_os_win32.c
@@ -499,7 +499,8 @@ int32_t mz_os_make_symlink(const char *path, const char *target_path) {
         return MZ_PARAM_ERROR;
 
 #ifdef MZ_WINRT_API
-    MEMORY_BASIC_INFORMATION mbi = { 0 };
+    MEMORY_BASIC_INFORMATION mbi;
+    memset(&mbi, 0, sizeof(mbi));
     VirtualQuery(VirtualQuery, &mbi, sizeof(mbi));
     kernel32_mod = (HMODULE)mbi.AllocationBase;
 #else
@@ -581,14 +582,15 @@ int32_t mz_os_read_symlink(const char *path, char *target_path, int32_t max_targ
         return MZ_PARAM_ERROR;
 
 #ifdef MZ_WINRT_API
-    CREATEFILE2_EXTENDED_PARAMETERS extendedParams = { 0 };
-    extendedParams.dwSize = sizeof(CREATEFILE2_EXTENDED_PARAMETERS);
-    extendedParams.dwFileAttributes = FILE_ATTRIBUTE_NORMAL;
-    extendedParams.dwFileFlags = FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT;
-    extendedParams.dwSecurityQosFlags = SECURITY_ANONYMOUS;
-    extendedParams.lpSecurityAttributes = NULL;
-    extendedParams.hTemplateFile = NULL;
-    handle = CreateFile2(path_wide, FILE_READ_EA, FILE_SHARE_READ | FILE_SHARE_WRITE, OPEN_EXISTING, &extendedParams);
+    CREATEFILE2_EXTENDED_PARAMETERS extended_params;
+    memset(&extended_params, 0, sizeof(extended_params));
+    extended_params.dwSize = sizeof(extended_params);
+    extended_params.dwFileAttributes = FILE_ATTRIBUTE_NORMAL;
+    extended_params.dwFileFlags = FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT;
+    extended_params.dwSecurityQosFlags = SECURITY_ANONYMOUS;
+    extended_params.lpSecurityAttributes = NULL;
+    extended_params.hTemplateFile = NULL;
+    handle = CreateFile2(path_wide, FILE_READ_EA, FILE_SHARE_READ | FILE_SHARE_WRITE, OPEN_EXISTING, &extended_params);
 #else
     handle = CreateFileW(path_wide, FILE_READ_EA, FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, OPEN_EXISTING,
         FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT, NULL);

--- a/mz_strm_os_win32.c
+++ b/mz_strm_os_win32.c
@@ -107,7 +107,7 @@ int32_t mz_stream_os_open(void *stream, const char *path, int32_t mode) {
         return MZ_PARAM_ERROR;
 
 #ifdef MZ_WINRT_API
-    win32->handle = CreateFile2W(path_wide, desired_access, share_mode,
+    win32->handle = CreateFile2(path_wide, desired_access, share_mode,
         creation_disposition, NULL);
 #else
     win32->handle = CreateFileW(path_wide, desired_access, share_mode, NULL,
@@ -173,7 +173,12 @@ int32_t mz_stream_os_write(void *stream, const void *buf, int32_t size) {
 static int32_t mz_stream_os_seekinternal(HANDLE handle, LARGE_INTEGER large_pos,
     LARGE_INTEGER *new_pos, uint32_t move_method) {
 #ifdef MZ_WINRT_API
-    return SetFilePointerEx(handle, pos, newPos, dwMoveMethod);
+    BOOL success = FALSE;
+    success = SetFilePointerEx(handle, large_pos, new_pos, move_method);
+    if ((success == FALSE) && (GetLastError() != NO_ERROR))
+        return MZ_SEEK_ERROR;
+
+    return MZ_OK;
 #else
     LONG high_part = 0;
     uint32_t pos = 0;


### PR DESCRIPTION
This fixes a couple of compile failures in case we are building for UWP. To get a working library, crypto has to be disabled, and dependencies reduced to a minimum:  ` cmake . -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION="10.0.17763.0" -DMZ_BZIP2=OFF -DMZ_LZMA=OFF -DMZ_ZSTD=OFF -DMZ_PKCRYPT=OFF -DMZ_WZAES=OFF`

Still haven't figured out how to get the executeables up and running, but that is for another day.