### PR TITLE
Expose zlib constants for backwards compat #747

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -711,7 +711,9 @@ target_include_directories(${MINIZIP_TARGET} PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 if(MZ_COMPAT)
     target_include_directories(${MINIZIP_TARGET} PUBLIC
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+        ${ZLIB_SOURCE_DIR}
+        ${ZLIB_BINARY_DIR})
 endif()
 
 # Install files

--- a/mz_compat.h
+++ b/mz_compat.h
@@ -15,6 +15,10 @@
 
 #include "mz.h"
 
+#ifndef ZLIB_H
+#include <zlib.h>
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -147,9 +151,6 @@ typedef const char *zipcharpc;
 #define ZIP_BADZIPFILE                  (-103)
 #define ZIP_INTERNALERROR               (-104)
 
-#ifndef Z_DEFLATED
-#define Z_DEFLATED                      (8)
-#endif
 #define Z_BZIP2ED                       (12)
 
 #define APPEND_STATUS_CREATE            (0)


### PR DESCRIPTION
Building a project that had an internal copy of minizip 1.x, but
preferring an external library, with minizip 4.x showed that the
compat layer was not exposing some constants from zlib that
minizip 1.x headers did.