### PR TITLE
Feature: dynamic pattern for selected files

### DIFF
--- a/doc/mz_zip_rw.md
+++ b/doc/mz_zip_rw.md
@@ -805,13 +805,13 @@ Sets the match pattern for entries in the zip file, if null all entries are matc
 **Return**
 |Type|Description|
 |-|-|
-|void|No return|
+|int32_t|[MZ_ERROR](mz_error.md) code, MZ_OK if successful|
 
 **Example**
 ```
 int32_t matches = 0;
 const char *pattern = "*.txt";
-mz_zip_reader_set_pattern(zip_reader, pattern, 1);
+if (mz_zip_reader_set_pattern(zip_reader, pattern, 1) == MZ_OK)
 if (mz_zip_reader_goto_first_entry(zip_reader) == MZ_OK) {
     do {
         matches += 1;

--- a/minizip.c
+++ b/minizip.c
@@ -386,7 +386,11 @@ int32_t minizip_extract(const char *path, const char *pattern, const char *desti
     if (!reader)
         return MZ_MEM_ERROR;
 
-    mz_zip_reader_set_pattern(reader, pattern, 1);
+    err = mz_zip_reader_set_pattern(reader, pattern, 1);
+    if (err != MZ_OK) {
+        mz_zip_reader_delete(&reader);
+        return err;
+    }
     mz_zip_reader_set_password(reader, password);
     mz_zip_reader_set_encoding(reader, options->encoding);
     mz_zip_reader_set_entry_cb(reader, options, minizip_extract_entry_cb);

--- a/mz_zip_rw.h
+++ b/mz_zip_rw.h
@@ -102,7 +102,7 @@ int32_t mz_zip_reader_save_all(void *handle, const char *destination_dir);
 
 /***************************************************************************/
 
-void mz_zip_reader_set_pattern(void *handle, const char *pattern, uint8_t ignore_case);
+int32_t mz_zip_reader_set_pattern(void *handle, const char *pattern, uint8_t ignore_case);
 /* Sets the match pattern for entries in the zip file, if null all entries are matched */
 
 void mz_zip_reader_set_password(void *handle, const char *password);


### PR DESCRIPTION
Fix: #855

The difference with #856 is that we're moving the `free(reader->pattern)` from `mz_zip_reader_close` to `mz_zip_reader_delete`.

cc @DreamHelium