### PR TITLE
Revert: Make `pattern` in `mz_zip_reader` dynamically assigned (#856)

### DIFF
--- a/mz_zip_rw.c
+++ b/mz_zip_rw.c
@@ -39,7 +39,7 @@ typedef struct mz_zip_reader_s {
     uint16_t hash_algorithm;
     uint16_t hash_digest_size;
     mz_zip_file *file_info;
-    char *pattern;
+    const char *pattern;
     uint8_t pattern_ignore_case;
     const char *password;
     void *overwrite_userdata;
@@ -228,11 +228,6 @@ int32_t mz_zip_reader_close(void *handle) {
     if (reader->mem_stream) {
         mz_stream_close(reader->mem_stream);
         mz_stream_delete(&reader->mem_stream);
-    }
-
-    if (reader->pattern) {
-        free(reader->pattern);
-        reader->pattern = NULL;
     }
 
     return err;
@@ -912,17 +907,7 @@ void mz_zip_reader_set_pattern(void *handle, const char *pattern, uint8_t ignore
     mz_zip_reader *reader = (mz_zip_reader *)handle;
     if (!reader)
         return;
-    free(reader->pattern);
-    reader->pattern = NULL;
-    if (pattern) {
-        /* pattern can be NULL */
-        int32_t pattern_size = (int32_t)strlen(pattern);
-        reader->pattern = (char *)calloc(pattern_size + 1, sizeof(char));
-        if (!reader->pattern)
-            /* Reference: `mz_zip_set_comment`, should return MZ_MEM_ERROR */
-            return;
-        strncpy(reader->pattern, pattern, pattern_size);
-    }
+    reader->pattern = pattern;
     reader->pattern_ignore_case = ignore_case;
 }
 


### PR DESCRIPTION
Alternative for: #874
Fix: #873

Undo: #856 / #855

cc @DreamHelium

This is a feature revert because:
- it's not optimal to force a copy of the `pattern` ; the caller of the API could have managed the lifetime of this `pattern` to be equal to the lifetime of the `reader` by themselves.
