### PR TITLE
align bzip and lzma streams for 64-bit platforms

### DIFF
--- a/mz_strm_bzip.c
+++ b/mz_strm_bzip.c
@@ -29,13 +29,13 @@ typedef struct mz_stream_bzip_s {
     int32_t mode;
     int32_t error;
     uint8_t buffer[INT16_MAX];
+    int8_t initialized;
     int32_t buffer_len;
     int16_t stream_end;
+    int16_t level;
     int64_t total_in;
     int64_t total_out;
     int64_t max_total_in;
-    int8_t initialized;
-    int16_t level;
 } mz_stream_bzip;
 
 /***************************************************************************/

--- a/mz_strm_lzma.c
+++ b/mz_strm_lzma.c
@@ -35,16 +35,16 @@ typedef struct mz_stream_lzma_s {
     int32_t mode;
     int32_t error;
     uint8_t buffer[INT16_MAX];
+    int8_t header;
     int32_t buffer_len;
+    int8_t initialized;
+    int16_t method;
     int64_t total_in;
     int64_t total_out;
     int64_t max_total_in;
     int64_t max_total_out;
-    int8_t initialized;
-    int8_t header;
     int32_t header_size;
     uint32_t preset;
-    int16_t method;
 } mz_stream_lzma;
 
 /***************************************************************************/


### PR DESCRIPTION
This PR will decrease costs copying, moving, and creating object-structures only for common 64bit processors due to the 8-byte data alignment.

Smaller size structure or class, higher chance putting into CPU cache. Most processors are already 64 bit, so the change won't make it any worse.

## Pahole output:

- Comment `/* XXX {n} bytes hole, try to pack */` shows where optimization is possible by rearranging the order of fields structures and classes

### Master

```c
struct mz_stream_lzma_s {
        mz_stream                  stream;               /*     0    16 */
        lzma_stream                lstream;              /*    16   136 */
        /* --- cacheline 2 boundary (128 bytes) was 24 bytes ago --- */
        int32_t                    mode;                 /*   152     4 */
        int32_t                    error;                /*   156     4 */
        uint8_t                    buffer[32767];        /*   160 32767 */

        /* XXX 1 byte hole, try to pack */

        /* --- cacheline 514 boundary (32896 bytes) was 32 bytes ago --- */
        int32_t                    buffer_len;           /* 32928     4 */

        /* XXX 4 bytes hole, try to pack */

        int64_t                    total_in;             /* 32936     8 */
        int64_t                    total_out;            /* 32944     8 */
        int64_t                    max_total_in;         /* 32952     8 */
        /* --- cacheline 515 boundary (32960 bytes) --- */
        int64_t                    max_total_out;        /* 32960     8 */
        int8_t                     initialized;          /* 32968     1 */
        int8_t                     header;               /* 32969     1 */

        /* XXX 2 bytes hole, try to pack */

        int32_t                    header_size;          /* 32972     4 */
        uint32_t                   preset;               /* 32976     4 */
        int16_t                    method;               /* 32980     2 */

        /* size: 32984, cachelines: 516, members: 15 */
        /* sum members: 32975, holes: 3, sum holes: 7 */
        /* padding: 2 */
        /* last cacheline: 24 bytes */
};

struct mz_stream_bzip_s {
        mz_stream                  stream;               /*     0    16 */
        bz_stream                  bzstream;             /*    16    80 */
        /* --- cacheline 1 boundary (64 bytes) was 32 bytes ago --- */
        int32_t                    mode;                 /*    96     4 */
        int32_t                    error;                /*   100     4 */
        uint8_t                    buffer[32767];        /*   104 32767 */

        /* XXX 1 byte hole, try to pack */

        /* --- cacheline 513 boundary (32832 bytes) was 40 bytes ago --- */
        int32_t                    buffer_len;           /* 32872     4 */
        int16_t                    stream_end;           /* 32876     2 */

        /* XXX 2 bytes hole, try to pack */

        int64_t                    total_in;             /* 32880     8 */
        int64_t                    total_out;            /* 32888     8 */
        /* --- cacheline 514 boundary (32896 bytes) --- */
        int64_t                    max_total_in;         /* 32896     8 */
        int8_t                     initialized;          /* 32904     1 */

        /* XXX 1 byte hole, try to pack */

        int16_t                    level;                /* 32906     2 */

        /* size: 32912, cachelines: 515, members: 12 */
        /* sum members: 32904, holes: 3, sum holes: 4 */
        /* padding: 4 */
        /* last cacheline: 16 bytes */
};

```

### This PR
```c
struct mz_stream_lzma_s {
        mz_stream                  stream;               /*     0    16 */
        lzma_stream                lstream;              /*    16   136 */
        /* --- cacheline 2 boundary (128 bytes) was 24 bytes ago --- */
        int32_t                    mode;                 /*   152     4 */
        int32_t                    error;                /*   156     4 */
        uint8_t                    buffer[32767];        /*   160 32767 */
        /* --- cacheline 514 boundary (32896 bytes) was 31 bytes ago --- */
        int8_t                     header;               /* 32927     1 */
        int32_t                    buffer_len;           /* 32928     4 */
        int8_t                     initialized;          /* 32932     1 */

        /* XXX 1 byte hole, try to pack */
                                                                                                                                                                                                                  
        int16_t                    method;               /* 32934     2 */                                                                                                                                        
        int64_t                    total_in;             /* 32936     8 */                                                                                                                                        
        int64_t                    total_out;            /* 32944     8 */                                                                                                                                        
        int64_t                    max_total_in;         /* 32952     8 */                                                                                                                                        
        /* --- cacheline 515 boundary (32960 bytes) --- */                                                                                                                                                        
        int64_t                    max_total_out;        /* 32960     8 */                                                                                                                                        
        int32_t                    header_size;          /* 32968     4 */                                                                                                                                        
        uint32_t                   preset;               /* 32972     4 */                                                                                                                                        
                                                                                                                                                                                                                  
        /* size: 32976, cachelines: 516, members: 15 */                                                                                                                                                           
        /* sum members: 32975, holes: 1, sum holes: 1 */                                                                                                                                                          
        /* last cacheline: 16 bytes */
};

struct mz_stream_bzip_s {
        mz_stream                  stream;               /*     0    16 */
        bz_stream                  bzstream;             /*    16    80 */
        /* --- cacheline 1 boundary (64 bytes) was 32 bytes ago --- */
        int32_t                    mode;                 /*    96     4 */
        int32_t                    error;                /*   100     4 */
        uint8_t                    buffer[32767];        /*   104 32767 */
        /* --- cacheline 513 boundary (32832 bytes) was 39 bytes ago --- */
        int8_t                     initialized;          /* 32871     1 */
        int32_t                    buffer_len;           /* 32872     4 */
        int16_t                    stream_end;           /* 32876     2 */
        int16_t                    level;                /* 32878     2 */
        int64_t                    total_in;             /* 32880     8 */
        int64_t                    total_out;            /* 32888     8 */
        /* --- cacheline 514 boundary (32896 bytes) --- */
        int64_t                    max_total_in;         /* 32896     8 */

        /* size: 32904, cachelines: 515, members: 12 */
        /* last cacheline: 8 bytes */
};

```

## Affected structs:
- mz_stream_lzma_s 32984 to 32976 bytes
- mz_stream_bzip_s 32912 to 32904 bytes