### PR TITLE
fix skipping individual files in reader_overwrite_cb

### DIFF
--- a/mz_zip_rw.c
+++ b/mz_zip_rw.c
@@ -699,8 +699,11 @@ int32_t mz_zip_reader_entry_save_file(void *handle, const char *path) {
     /* Check if file exists and ask if we want to overwrite */
     if (reader->overwrite_cb && mz_os_file_exists(pathwfs) == MZ_OK) {
         err_cb = reader->overwrite_cb(reader, reader->overwrite_userdata, reader->file_info, pathwfs);
-        if (err_cb != MZ_OK)
+        if (err_cb != MZ_OK) {
+            if (err_cb == MZ_EXIST_ERROR)
+                err_cb = MZ_OK;
             goto save_cleanup;
+        }
         /* We want to overwrite the file so we delete the existing one */
         mz_os_unlink(pathwfs);
     }


### PR DESCRIPTION
The documentation for the return value of reader_overwrite_cb says "MZ_OK to overwrite, MZ_EXIST_ERROR to skip". This implies skipping a single file, not all future files. Change the code to match the documentation.

---

I thought about adding MZ_SKIP_ONE to preserve current behaviour, but I couldn't think of a case where you'd need to "skip all" at this layer. (For the minizip.c case, a "Ne(v)er" option the inverse of "(A)lways" could be added the same way, with a flag that is checked each loop at the application layer).