### PR TITLE
zstd: add MZ_STREAM_PROP_COMPRESS_THREADS

### DIFF
--- a/mz_strm.h
+++ b/mz_strm.h
@@ -17,17 +17,18 @@ extern "C" {
 
 /***************************************************************************/
 
-#define MZ_STREAM_PROP_TOTAL_IN        (1)
-#define MZ_STREAM_PROP_TOTAL_IN_MAX    (2)
-#define MZ_STREAM_PROP_TOTAL_OUT       (3)
-#define MZ_STREAM_PROP_TOTAL_OUT_MAX   (4)
-#define MZ_STREAM_PROP_HEADER_SIZE     (5)
-#define MZ_STREAM_PROP_FOOTER_SIZE     (6)
-#define MZ_STREAM_PROP_DISK_SIZE       (7)
-#define MZ_STREAM_PROP_DISK_NUMBER     (8)
-#define MZ_STREAM_PROP_COMPRESS_LEVEL  (9)
-#define MZ_STREAM_PROP_COMPRESS_METHOD (10)
-#define MZ_STREAM_PROP_COMPRESS_WINDOW (11)
+#define MZ_STREAM_PROP_TOTAL_IN         (1)
+#define MZ_STREAM_PROP_TOTAL_IN_MAX     (2)
+#define MZ_STREAM_PROP_TOTAL_OUT        (3)
+#define MZ_STREAM_PROP_TOTAL_OUT_MAX    (4)
+#define MZ_STREAM_PROP_HEADER_SIZE      (5)
+#define MZ_STREAM_PROP_FOOTER_SIZE      (6)
+#define MZ_STREAM_PROP_DISK_SIZE        (7)
+#define MZ_STREAM_PROP_DISK_NUMBER      (8)
+#define MZ_STREAM_PROP_COMPRESS_LEVEL   (9)
+#define MZ_STREAM_PROP_COMPRESS_METHOD  (10)
+#define MZ_STREAM_PROP_COMPRESS_WINDOW  (11)
+#define MZ_STREAM_PROP_COMPRESS_THREADS (12)
 
 /***************************************************************************/
 

--- a/mz_strm_zstd.c
+++ b/mz_strm_zstd.c
@@ -308,6 +308,14 @@ int32_t mz_stream_zstd_set_prop_int64(void *stream, int32_t prop, int64_t value)
     case MZ_STREAM_PROP_TOTAL_IN_MAX:
         zstd->max_total_in = value;
         return MZ_OK;
+    case MZ_STREAM_PROP_COMPRESS_THREADS:
+        if (zstd->zcstream) {
+            size_t rv = ZSTD_CCtx_setParameter(zstd->zcstream, ZSTD_c_nbWorkers, value);
+            if (rv == (size_t)value) {
+                return MZ_OK;
+            }
+        }
+        return MZ_PARAM_ERROR;
     }
     return MZ_EXIST_ERROR;
 }


### PR DESCRIPTION
Add a property to control the number of threads used for zstd compression.

---

In theory, somebody could implement this property for lzma, but I don't think zlib-ng has a way to use multiple threads.