### PR TITLE
harden mz_zip_writer_add_file against link following

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -466,6 +466,11 @@ else()
     list(APPEND STDLIB_DEF -D_POSIX_C_SOURCE=200809L -D_BSD_SOURCE -D_DEFAULT_SOURCE)
     list(APPEND MINIZIP_SRC mz_os_posix.c mz_strm_os_posix.c)
 
+    if(APPLE)
+        # Despite being part of POSIX 2008, macOS thinks that O_NOFOLLOW is still a non-standard extension
+        list(APPEND STDLIB_DEF -D_DARWIN_C_SOURCE)
+    endif()
+
     if(MZ_PKCRYPT OR MZ_WZAES)
         if(MZ_OPENSSL)
             list(APPEND MINIZIP_DEP_PKG OpenSSL)

--- a/doc/mz_open_mode.md
+++ b/doc/mz_open_mode.md
@@ -10,3 +10,4 @@ Stream open flag enumeration.
 |MZ_OPEN_MODE_APPEND|0x04|Open for appending|
 |MZ_OPEN_MODE_CREATE|0x08|Open for creating|
 |MZ_OPEN_MODE_EXISTING|0x10|Open existing|
+|MZ_OPEN_MODE_NOFOLLOW|0x20|Do not follow symlinks|

--- a/doc/mz_zip_rw.md
+++ b/doc/mz_zip_rw.md
@@ -81,6 +81,9 @@ The _mz_zip_reader_ and _mz_zip_writer_ objects allows you to easily extract or 
   - [mz\_zip\_writer\_set\_aes](#mz_zip_writer_set_aes)
   - [mz\_zip\_writer\_set\_compress\_method](#mz_zip_writer_set_compress_method)
   - [mz\_zip\_writer\_set\_compress\_level](#mz_zip_writer_set_compress_level)
+  - [mz\_zip\_writer\_set\_follow\_links](#mz_zip_writer_set_follow_links)
+  - [mz\_zip\_writer\_get\_follow\_links](#mz_zip_writer_get_follow_links)
+  - [mz\_zip\_writer\_set\_store\_links](#mz_zip_writer_set_store_links)
   - [mz\_zip\_writer\_set\_zip\_cd](#mz_zip_writer_set_zip_cd)
   - [mz\_zip\_writer\_set\_overwrite\_cb](#mz_zip_writer_set_overwrite_cb)
   - [mz\_zip\_writer\_set\_password\_cb](#mz_zip_writer_set_password_cb)
@@ -1792,6 +1795,68 @@ Sets the compression level when adding files in zip.
 **Example**
 ```
 mz_zip_writer_set_compress_level(zip_writer, MZ_COMPRESS_LEVEL_BEST);
+```
+
+### mz_zip_writer_set_follow_links
+
+Sets whether symbolic links will be followed when traversing directories and files to add.
+
+**Arguments**
+|Type|Name|Description|
+|-|-|-|
+|void *|handle|_mz_zip_writer_ instance|
+|uint8_t|follow_links|Follow symbolic links if 1|
+
+**Return**
+|Type|Description|
+|-|-|
+|void|No return|
+
+**Example**
+```
+mz_zip_writer_set_follow_links(zip_writer, 1);
+```
+
+### mz_zip_writer_get_follow_links
+
+Gets whether symbolic links will be followed when traversing directories and files to add.
+
+**Arguments**
+|Type|Name|Description|
+|-|-|-|
+|void *|handle|_mz_zip_writer_ instance|
+|uint8_t *|follow_links|Pointer to store if following symbolic links|
+
+**Return**
+|Type|Description|
+|-|-|
+|int32_t|[MZ_ERROR](mz_error.md) code, MZ_OK if successful|
+
+**Example**
+```
+uint8_t follow = 0;
+mz_zip_writer_get_follow_links(zip_writer, &follow);
+printf("Following symbolic links: %s\n", (follow) ? "yes" : "no");
+```
+
+### mz_zip_writer_set_store_links
+
+Store symbolic links in zip file as symbolic links.
+
+**Arguments**
+|Type|Name|Description|
+|-|-|-|
+|void *|handle|_mz_zip_writer_ instance|
+|uint8_t|store_links|Store symbolic links if 1|
+
+**Return**
+|Type|Description|
+|-|-|
+|void|No return|
+
+**Example**
+```
+mz_zip_writer_set_store_links(zip_writer, 1);
 ```
 
 ### mz_zip_writer_set_zip_cd

--- a/mz.h
+++ b/mz.h
@@ -53,6 +53,7 @@
 #define MZ_OPEN_MODE_APPEND    (0x04)
 #define MZ_OPEN_MODE_CREATE    (0x08)
 #define MZ_OPEN_MODE_EXISTING  (0x10)
+#define MZ_OPEN_MODE_NOFOLLOW  (0x20)
 
 /* MZ_SEEK */
 #define MZ_SEEK_SET (0)

--- a/mz_strm_os_posix.c
+++ b/mz_strm_os_posix.c
@@ -19,6 +19,8 @@
 
 #include <stdio.h> /* fopen, fread.. */
 #include <errno.h>
+#include <unistd.h>  // open, close, ...
+#include <fcntl.h>   // O_NOFOLLOW, ...
 
 /***************************************************************************/
 
@@ -67,20 +69,33 @@ typedef struct mz_stream_posix_s {
 int32_t mz_stream_os_open(void *stream, const char *path, int32_t mode) {
     mz_stream_posix *posix = (mz_stream_posix *)stream;
     const char *mode_fopen = NULL;
+    int mode_open = 0;
+    int fd;
 
     if (!path)
         return MZ_PARAM_ERROR;
 
-    if ((mode & MZ_OPEN_MODE_READWRITE) == MZ_OPEN_MODE_READ)
-        mode_fopen = "rb";
-    else if (mode & MZ_OPEN_MODE_APPEND)
-        mode_fopen = "r+b";
-    else if (mode & MZ_OPEN_MODE_CREATE)
-        mode_fopen = "wb";
-    else
+    if ((mode & MZ_OPEN_MODE_READWRITE) == MZ_OPEN_MODE_READ) {
+        mode_fopen = "r";
+        mode_open = O_RDONLY;
+    } else if (mode & MZ_OPEN_MODE_APPEND) {
+        mode_fopen = "r+";
+        mode_open = O_RDWR;
+    } else if (mode & MZ_OPEN_MODE_CREATE) {
+        mode_fopen = "w";
+        mode_open = O_WRONLY | O_CREAT | O_TRUNC;
+    } else
         return MZ_OPEN_ERROR;
 
-    posix->handle = fopen64(path, mode_fopen);
+    if (mode & MZ_OPEN_MODE_NOFOLLOW)
+        mode_open |= O_NOFOLLOW;
+
+    fd = open(path, mode_open, S_IRUSR | S_IWUSR | S_IRGRP);
+    if (fd != -1) {
+        posix->handle = fdopen(fd, mode_fopen);
+        if (!posix->handle)
+            close(fd);
+    }
     if (!posix->handle) {
         posix->error = errno;
         return MZ_OPEN_ERROR;

--- a/mz_zip_rw.c
+++ b/mz_zip_rw.c
@@ -1629,10 +1629,13 @@ int32_t mz_zip_writer_add_file(void *handle, const char *path, const char *filen
         if (err == MZ_OK)
             file_info.linkname = link_path;
     } else if (mz_os_is_dir(path) != MZ_OK) {
+        uint32_t mode = MZ_OPEN_MODE_READ;
         stream = mz_stream_os_create();
         if (!stream)
             return MZ_STREAM_ERROR;
-        err = mz_stream_os_open(stream, path, MZ_OPEN_MODE_READ);
+        if (!writer->follow_links)
+            mode |= MZ_OPEN_MODE_NOFOLLOW;
+        err = mz_stream_os_open(stream, path, mode);
     }
 
     if (err == MZ_OK)
@@ -1832,6 +1835,14 @@ void mz_zip_writer_set_compress_level(void *handle, int16_t compress_level) {
 void mz_zip_writer_set_follow_links(void *handle, uint8_t follow_links) {
     mz_zip_writer *writer = (mz_zip_writer *)handle;
     writer->follow_links = follow_links;
+}
+
+int32_t mz_zip_writer_get_follow_links(void *handle, uint8_t *follow_links) {
+    mz_zip_writer *writer = (mz_zip_writer *)handle;
+    if (!follow_links)
+        return MZ_PARAM_ERROR;
+    *follow_links = writer->follow_links;
+    return MZ_OK;
 }
 
 void mz_zip_writer_set_store_links(void *handle, uint8_t store_links) {

--- a/mz_zip_rw.h
+++ b/mz_zip_rw.h
@@ -236,6 +236,9 @@ void mz_zip_writer_set_compress_level(void *handle, int16_t compress_level);
 void mz_zip_writer_set_follow_links(void *handle, uint8_t follow_links);
 /* Follow symbolic links when traversing directories and files to add */
 
+int32_t mz_zip_writer_get_follow_links(void *handle, uint8_t *follow_links);
+/* Gets whether to follow symbolic links when traversing directories and files to add */
+
 void mz_zip_writer_set_store_links(void *handle, uint8_t store_links);
 /* Store symbolic links in zip file */
 


### PR DESCRIPTION
There is a small race where a file can be replaced with a link between the call to mz_os_is_symlink and the call to mz_stream_os_open. Add MZ_OPEN_MODE_NOFOLLOW to make sure that (on POSIX) a link cannot be followed.