### PR TITLE
fix stack overrun in mz_os_utf8_string_create

### DIFF
--- a/mz_os_posix.c
+++ b/mz_os_posix.c
@@ -46,6 +46,8 @@
 #if defined(HAVE_ICONV)
 char *mz_os_utf8_string_create(const char *string, int32_t encoding) {
     iconv_t cd;
+    /// up to CP2147483647
+    char string_encoding[13];
     const char *from_encoding = NULL;
     size_t result = 0;
     size_t string_length = 0;
@@ -59,8 +61,6 @@ char *mz_os_utf8_string_create(const char *string, int32_t encoding) {
     if (encoding == MZ_ENCODING_UTF8)
         from_encoding = "UTF-8";
     else {
-        /// up to CP2147483647
-        char string_encoding[13];
         snprintf(string_encoding, sizeof(string_encoding), "CP%03" PRId32, encoding);
         from_encoding = string_encoding;
     }


### PR DESCRIPTION
The string_encoding variable goes out of scope right after assignment to from_encoding. Referencing from_encoding after this point is technically a use-after-free error, which leads to arbitrary (undefined) behaviour.

Move string_encoding up to function scope so it survives for as long as it could be referenced.