### PR TITLE
Update FindZLIB-NG.cmake

### DIFF
--- a/cmake/FindZLIB-NG.cmake
+++ b/cmake/FindZLIB-NG.cmake
@@ -1,6 +1,6 @@
 find_path(ZLIB-NG_INCLUDE_DIRS NAMES zlib-ng.h)
 
-if(ZLIB_INCLUDE_DIRS)
+if(ZLIB-NG_INCLUDE_DIRS)
     set(ZLIB-NG_LIBRARY_DIRS ${ZLIB-NG_INCLUDE_DIRS})
 
     if("${ZLIB-NG_LIBRARY_DIRS}" MATCHES "/include$")
@@ -13,7 +13,7 @@ if(ZLIB_INCLUDE_DIRS)
     endif()
 endif()
 
-find_library(ZLIB-NG_LIBRARY NAMES z-ng libz-ng libz-ng.a)
+find_library(ZLIB-NG_LIBRARY NAMES z-ng libz-ng libz-ng.a zlib-ng zlibstatic-ng)
 
 set(ZLIB-NG_LIBRARIES ${ZLIB-NG_LIBRARY})
 set(ZLIB-NG_INCLUDE_DIRS ${ZLIB-NG_INCLUDE_DIRS})

--- a/cmake/FindZLIB-NG.cmake
+++ b/cmake/FindZLIB-NG.cmake
@@ -13,7 +13,7 @@ if(ZLIB-NG_INCLUDE_DIRS)
     endif()
 endif()
 
-set (LIB_NAMES z-ng libz-ng libz-ng.a)
+set(LIB_NAMES z-ng libz-ng libz-ng.a)
 
 if(BUILD_SHARED_LIBS)
     list(APPEND LIB_NAMES zlib-ng)	

--- a/cmake/FindZLIB-NG.cmake
+++ b/cmake/FindZLIB-NG.cmake
@@ -13,7 +13,16 @@ if(ZLIB-NG_INCLUDE_DIRS)
     endif()
 endif()
 
-find_library(ZLIB-NG_LIBRARY NAMES z-ng libz-ng libz-ng.a zlib-ng zlibstatic-ng)
+set (LIB_NAMES z-ng libz-ng libz-ng.a)
+
+if(BUILD_SHARED_LIBS)
+    list(APPEND LIB_NAMES zlib-ng)	
+else()
+    list(APPEND LIB_NAMES zlibstatic-ng)
+endif()
+
+find_library(ZLIB-NG_LIBRARY NAMES ${LIB_NAMES})
+
 
 set(ZLIB-NG_LIBRARIES ${ZLIB-NG_LIBRARY})
 set(ZLIB-NG_INCLUDE_DIRS ${ZLIB-NG_INCLUDE_DIRS})


### PR DESCRIPTION
Adding library names that zlib generates so that it can be found by minizip-ng. Fixes #903 