### PR TITLE
fix missing includes in header files

### DIFF
--- a/mz_crypt.h
+++ b/mz_crypt.h
@@ -11,6 +11,14 @@
 #ifndef MZ_CRYPT_H
 #define MZ_CRYPT_H
 
+#if defined(HAVE_STDINT_H)
+#  include <stdint.h>
+#elif defined(__has_include)
+#  if __has_include(<stdint.h>)
+#    include <stdint.h>
+#  endif
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/mz_os.h
+++ b/mz_os.h
@@ -11,6 +11,14 @@
 #ifndef MZ_OS_H
 #define MZ_OS_H
 
+#if defined(HAVE_STDINT_H)
+#  include <stdint.h>
+#elif defined(__has_include)
+#  if __has_include(<stdint.h>)
+#    include <stdint.h>
+#  endif
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/mz_strm.h
+++ b/mz_strm.h
@@ -11,6 +11,14 @@
 #ifndef MZ_STREAM_H
 #define MZ_STREAM_H
 
+#if defined(HAVE_STDINT_H)
+#  include <stdint.h>
+#elif defined(__has_include)
+#  if __has_include(<stdint.h>)
+#    include <stdint.h>
+#  endif
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/mz_strm_buf.h
+++ b/mz_strm_buf.h
@@ -13,6 +13,14 @@
 #ifndef MZ_STREAM_BUFFERED_H
 #define MZ_STREAM_BUFFERED_H
 
+#if defined(HAVE_STDINT_H)
+#  include <stdint.h>
+#elif defined(__has_include)
+#  if __has_include(<stdint.h>)
+#    include <stdint.h>
+#  endif
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/mz_strm_bzip.h
+++ b/mz_strm_bzip.h
@@ -11,6 +11,14 @@
 #ifndef MZ_STREAM_BZIP_H
 #define MZ_STREAM_BZIP_H
 
+#if defined(HAVE_STDINT_H)
+#  include <stdint.h>
+#elif defined(__has_include)
+#  if __has_include(<stdint.h>)
+#    include <stdint.h>
+#  endif
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/mz_strm_libcomp.h
+++ b/mz_strm_libcomp.h
@@ -11,7 +11,13 @@
 #ifndef MZ_STREAM_LIBCOMP_H
 #define MZ_STREAM_LIBCOMP_H
 
-#include <stdint.h>
+#if defined(HAVE_STDINT_H)
+#  include <stdint.h>
+#elif defined(__has_include)
+#  if __has_include(<stdint.h>)
+#    include <stdint.h>
+#  endif
+#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/mz_strm_lzma.h
+++ b/mz_strm_lzma.h
@@ -11,6 +11,14 @@
 #ifndef MZ_STREAM_LZMA_H
 #define MZ_STREAM_LZMA_H
 
+#if defined(HAVE_STDINT_H)
+#  include <stdint.h>
+#elif defined(__has_include)
+#  if __has_include(<stdint.h>)
+#    include <stdint.h>
+#  endif
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/mz_strm_mem.h
+++ b/mz_strm_mem.h
@@ -11,6 +11,14 @@
 #ifndef MZ_STREAM_MEM_H
 #define MZ_STREAM_MEM_H
 
+#if defined(HAVE_STDINT_H)
+#  include <stdint.h>
+#elif defined(__has_include)
+#  if __has_include(<stdint.h>)
+#    include <stdint.h>
+#  endif
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/mz_strm_os.h
+++ b/mz_strm_os.h
@@ -11,6 +11,14 @@
 #ifndef MZ_STREAM_OS_H
 #define MZ_STREAM_OS_H
 
+#if defined(HAVE_STDINT_H)
+#  include <stdint.h>
+#elif defined(__has_include)
+#  if __has_include(<stdint.h>)
+#    include <stdint.h>
+#  endif
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/mz_strm_pkcrypt.h
+++ b/mz_strm_pkcrypt.h
@@ -11,6 +11,14 @@
 #ifndef MZ_STREAM_PKCRYPT_H
 #define MZ_STREAM_PKCRYPT_H
 
+#if defined(HAVE_STDINT_H)
+#  include <stdint.h>
+#elif defined(__has_include)
+#  if __has_include(<stdint.h>)
+#    include <stdint.h>
+#  endif
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/mz_strm_split.h
+++ b/mz_strm_split.h
@@ -11,6 +11,14 @@
 #ifndef MZ_STREAM_SPLIT_H
 #define MZ_STREAM_SPLIT_H
 
+#if defined(HAVE_STDINT_H)
+#  include <stdint.h>
+#elif defined(__has_include)
+#  if __has_include(<stdint.h>)
+#    include <stdint.h>
+#  endif
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/mz_strm_wzaes.h
+++ b/mz_strm_wzaes.h
@@ -11,6 +11,14 @@
 #ifndef MZ_STREAM_WZAES_SHA1_H
 #define MZ_STREAM_WZAES_SHA1_H
 
+#if defined(HAVE_STDINT_H)
+#  include <stdint.h>
+#elif defined(__has_include)
+#  if __has_include(<stdint.h>)
+#    include <stdint.h>
+#  endif
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/mz_strm_zlib.h
+++ b/mz_strm_zlib.h
@@ -11,6 +11,14 @@
 #ifndef MZ_STREAM_ZLIB_H
 #define MZ_STREAM_ZLIB_H
 
+#if defined(HAVE_STDINT_H)
+#  include <stdint.h>
+#elif defined(__has_include)
+#  if __has_include(<stdint.h>)
+#    include <stdint.h>
+#  endif
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/mz_strm_zstd.h
+++ b/mz_strm_zstd.h
@@ -12,6 +12,14 @@
 #ifndef MZ_STREAM_ZSTD_H
 #define MZ_STREAM_ZSTD_H
 
+#if defined(HAVE_STDINT_H)
+#  include <stdint.h>
+#elif defined(__has_include)
+#  if __has_include(<stdint.h>)
+#    include <stdint.h>
+#  endif
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/mz_zip.h
+++ b/mz_zip.h
@@ -16,6 +16,16 @@
 #ifndef MZ_ZIP_H
 #define MZ_ZIP_H
 
+#include <time.h>
+
+#if defined(HAVE_STDINT_H)
+#  include <stdint.h>
+#elif defined(__has_include)
+#  if __has_include(<stdint.h>)
+#    include <stdint.h>
+#  endif
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/mz_zip_rw.h
+++ b/mz_zip_rw.h
@@ -11,6 +11,14 @@
 #ifndef MZ_ZIP_RW_H
 #define MZ_ZIP_RW_H
 
+#if defined(HAVE_STDINT_H)
+#  include <stdint.h>
+#elif defined(__has_include)
+#  if __has_include(<stdint.h>)
+#    include <stdint.h>
+#  endif
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
Most header files are missing `stdint.h`. I copied the include mechanism from `mz.h`.

`mz_zip.h` is using `time_t` and doesn't include `time.h`.

With this changes you can just include `mz_zip.h` (and the other headers) in your own project without caring that you previously included the missing standard header files.