### PR TITLE
`mz_stream_zstd_set_prop_int64`: Implicit conversion loses integer precision: 'int64_t' (aka 'long long') to 'int'

### DIFF
--- a/mz_strm_zstd.c
+++ b/mz_strm_zstd.c
@@ -310,7 +310,7 @@ int32_t mz_stream_zstd_set_prop_int64(void *stream, int32_t prop, int64_t value)
         return MZ_OK;
     case MZ_STREAM_PROP_COMPRESS_THREADS:
         if (zstd->zcstream) {
-            size_t rv = ZSTD_CCtx_setParameter(zstd->zcstream, ZSTD_c_nbWorkers, value);
+            size_t rv = ZSTD_CCtx_setParameter(zstd->zcstream, ZSTD_c_nbWorkers, (int)value);
             if (rv == (size_t)value) {
                 return MZ_OK;
             }


### PR DESCRIPTION
Warning since #888 by @peterh 

![Image](https://github.com/user-attachments/assets/c95ddc41-df5a-407f-8f7b-011c998155e2)

Solution: same as line 306, we make the conversion explicit with a cast.