### PR TITLE
Bump GoogleTest to 1.16

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -26,7 +26,7 @@ if(NOT TARGET GTest::GTest)
         if (CMAKE_CXX_COMPILER_ID MATCHES "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS_EQUAL 5.3)
             set(GTEST_TAG release-1.10.0)
         else()
-            set(GTEST_TAG v1.13.0)
+            set(GTEST_TAG v1.16.0)
         endif()
     endif()
 


### PR DESCRIPTION
This fixes the CMake build warning:
>CMake Deprecation Warning at build/_deps/googletest-src/CMakeLists.txt:4 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.

The fix landed in GoogleTest 1.14.0 (https://github.com/google/googletest/commit/29836977ef1c664588daeb035591c18a912e7c50).
Based on Release Notes, I didn't see any harm to adopt GoogleTest 1.16.0 directly.