### PR TITLE
fix #915: headers should not include there dependencies

### DIFF
--- a/mz_strm_libcomp.h
+++ b/mz_strm_libcomp.h
@@ -11,8 +11,6 @@
 #ifndef MZ_STREAM_LIBCOMP_H
 #define MZ_STREAM_LIBCOMP_H
 
-#include <stdint.h>
-
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
According to #915, users should always include `mz.h` before including any of the other headers. The other headers should explicitly not make any includes in order to fulfill their dependencies themselves.