### PR TITLE
Avoid ruby codeql failure

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,9 +26,10 @@ jobs:
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v4
+      with:
+        languages: c-cpp
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
       uses: github/codeql-action/autobuild@v4
 


### PR DESCRIPTION
Avoid a recurring failure:
>CodeQL detected code written in C/C++ and GitHub Actions, but not any written in Ruby. Confirm that there is some source code for Ruby in the project.

https://github.com/Coeur/minizip/actions/runs/19191333597