### PR TITLE
Compatible with systems without symbolic links

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,6 +162,16 @@ check_function_exists(fseeko HAVE_FSEEKO)
 if(NOT HAVE_FSEEKO)
     list(APPEND STDLIB_DEF -DNO_FSEEKO)
 endif()
+# Check for fseeko symlink
+check_function_exists(symlink HAVE_SYMLINK)
+if(NOT HAVE_SYMLINK)
+    list(APPEND STDLIB_DEF -DNO_SYMLINK)
+endif()
+# Check for fseeko readlink
+check_function_exists(readlink HAVE_READLINK)
+if(NOT HAVE_READLINK)
+    list(APPEND STDLIB_DEF -DNO_READLINK)
+endif()
 
 if(MZ_LIBCOMP)
     if(APPLE)

--- a/mz_os_posix.c
+++ b/mz_os_posix.c
@@ -324,12 +324,19 @@ int32_t mz_os_is_symlink(const char *path) {
 }
 
 int32_t mz_os_make_symlink(const char *path, const char *target_path) {
+#if defined(NO_SYMLINK)
+    return MZ_SUPPORT_ERROR;
+#else	
     if (symlink(target_path, path) != 0)
         return MZ_INTERNAL_ERROR;
     return MZ_OK;
+#endif
 }
 
 int32_t mz_os_read_symlink(const char *path, char *target_path, int32_t max_target_path) {
+#if defined(NO_READLINK)
+    return MZ_SUPPORT_ERROR;
+#else
     size_t length = 0;
 
     length = (size_t)readlink(path, target_path, max_target_path - 1);
@@ -338,6 +345,7 @@ int32_t mz_os_read_symlink(const char *path, char *target_path, int32_t max_targ
 
     target_path[length] = 0;
     return MZ_OK;
+#endif
 }
 
 uint64_t mz_os_ms_time(void) {


### PR DESCRIPTION
Check if the symlink and readlink functions exist, and define NO_SYMLINK and NO_READLINK based on the results. 

VitaSDK will be recognized as Linux, but it does not support symbolic links.