### PR TITLE
Fix modified_date when zipping

### DIFF
--- a/compat/zip.c
+++ b/compat/zip.c
@@ -178,9 +178,7 @@ static time_t zipConvertZipDateToTime(tm_zip tmz_date) {
     struct tm tm_date;
     memset(&tm_date, 0, sizeof(struct tm));
     memcpy(&tm_date, &tmz_date, sizeof(tm_zip));
-    tm_date.tm_year -= 1900;
-    tm_date.tm_isdst = -1;
-    return mz_zip_tm_to_time_t(&tm_date);
+    return mz_zip_dosdate_to_time_t(mz_zip_tm_to_dosdate(&tm_date));
 }
 
 int zipOpenNewFileInZip5(zipFile file, const char *filename, const zip_fileinfo *zipfi, const void *extrafield_local,


### PR DESCRIPTION
This is an experimental attempt to fix #921 by reverting one of the lines modified by https://github.com/zlib-ng/minizip-ng/commit/7df56f7cc8438b1b67c881cad049b29bf075bccd.

This fix is untested on my end, and purely based on code review.