### PR TITLE
Add workflow_dispatch to all workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 name: Build
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -248,7 +248,7 @@ jobs:
     - name: Run test cases
       run: ctest --output-on-failure -C ${{ matrix.build-config || 'Release' }}
       working-directory: ${{ matrix.build-dir }}
-      
+
     - name: Setup python
       uses: actions/setup-python@v6
       if: always() && matrix.codecov

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,6 +2,7 @@ name: CodeQL
 on:
   push:
   pull_request:
+  workflow_dispatch:
   schedule:
     - cron: '0 1 * * 4'
 concurrency:

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,5 +1,5 @@
 name: OSS-Fuzz
-on: [pull_request]
+on: [pull_request, workflow_dispatch]
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
This allows either interactive running of the workflow files on the GitHub web site, or, more importantly, via the  [gh CLI executable](https://github.com/cli/cli).

