### PR TITLE
Fix #941: fix undeclared identifier error of S_IWUSR

### DIFF
--- a/mz_strm_os_posix.c
+++ b/mz_strm_os_posix.c
@@ -17,10 +17,11 @@
 #include "mz_strm.h"
 #include "mz_strm_os.h"
 
-#include <stdio.h> /* fopen, fread.. */
+#include <stdio.h> /* fopen, fread, ... */
 #include <errno.h>
-#include <unistd.h>  // open, close, ...
-#include <fcntl.h>   // O_NOFOLLOW, ...
+#include <sys/stat.h> /* S_IRUSR, S_IWUSR, ... */
+#include <unistd.h>   /* open, close, ... */
+#include <fcntl.h>    /* O_NOFOLLOW, ... */
 
 /***************************************************************************/
 


### PR DESCRIPTION
Fixes #941. POSIX defines these macros in `<sys/stat.h>`.