### PR TITLE
Replace deprecated FetchContent_GetProperties with FetchContent_MakeAvailable

### DIFF
--- a/cmake/clone-repo.cmake
+++ b/cmake/clone-repo.cmake
@@ -23,7 +23,7 @@ macro(clone_repo name url tag)
             GIT_TAG ${${name_upper}_TAG}
             SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/third_party/${name_lower})
 
-        FetchContent_GetProperties(${name} POPULATED ${name_lower}_POPULATED)
+        FetchContent_MakeAvailable(${name})
 
         if(NOT ${name_lower}_POPULATED)
             FetchContent_Populate(${name})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -35,7 +35,7 @@ if(NOT TARGET GTest::GTest)
         GIT_REPOSITORY ${GTEST_REPOSITORY}
         GIT_TAG ${GTEST_TAG})
 
-    FetchContent_GetProperties(googletest)
+    FetchContent_MakeAvailable(googletest)
     if(NOT googletest_POPULATED)
         FetchContent_Populate(googletest)
         add_subdirectory(${googletest_SOURCE_DIR} ${googletest_BINARY_DIR} EXCLUDE_FROM_ALL)


### PR DESCRIPTION
Fix for #943

Replace use of `FetchContent_Populate` with `FetchContent_MakeAvailable`

```
CMake Warning (dev) at /snap/cmake/1509/share/cmake-4.2/Modules/FetchContent.cmake:1963 (message):
  Calling FetchContent_Populate(googletest) is deprecated, call
  FetchContent_MakeAvailable(googletest) instead.  Policy CMP0169 can be set
  to OLD to allow FetchContent_Populate(googletest) to be called directly for
  now, but the ability to call it with declared details will be removed
  completely in a future version.
Call Stack (most recent call first):
  test/CMakeLists.txt:41 (FetchContent_Populate)
This warning is for project developers.  Use -Wno-dev to suppress it.
```