### PR TITLE
Ppmd dependabot

### DIFF
--- a/.github/workflows/ppmd-dependabot.yml
+++ b/.github/workflows/ppmd-dependabot.yml
@@ -1,0 +1,34 @@
+# The PPMd sources used in mnizip-ng come from https://github.com/ip7z/7zip
+#
+# This simple depndabot-like script checks if the latest upstream
+# version of PPMd matches the hard-wired version used in minizip-ng.
+
+name: PPMd Dependabot
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 2 1 * *'  # Monthly on the first day of the month at 2am
+env:
+  TERM: xterm-256color
+
+jobs:
+  check:
+    name: Upstream
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check Upstream PPMd Version
+      run: |
+        # This is the hard-wired PPMd version that minizip-ng is built with.
+        expected_ppmd_version="25.01"
+
+        # get the latest PPMd version from upstream 7zip repo
+        upstream_ppmd_version=$( git ls-remote --tags --sort=-v:refname https://github.com/ip7z/7zip  | head -n 1 | sed -e 's#.*/##' )
+
+        if [ "$upstream_ppmd_version" != "$expected_ppmd_version" ]; then
+            echo "ERROR: PPMd version mismatch!"
+            echo "    Expected PPMd version: '$expected_ppmd_version'"
+            echo "    Upstream PPMd version: '$upstream_ppmd_version'"
+            exit 1
+        else
+            echo "All OK. Upstream PPMd matches expected version: '$expected_ppmd_version'"
+        fi

--- a/.github/workflows/ppmd-dependabot.yml
+++ b/.github/workflows/ppmd-dependabot.yml
@@ -8,8 +8,6 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 2 1 * *'  # Monthly on the first day of the month at 2am
-env:
-  TERM: xterm-256color
 
 jobs:
   check:


### PR DESCRIPTION
This is a quick-and-dirty bespoke dependabot that checks upstream at https://github.com/ip7z/7zip for a release version different from the one we have hard-wired into `CMakeLists.txt` and this workflow file.

All the workflow does is fail is it finds a difference. No fancy stuff like the real dependabot, so it won't automatically create a PR.

As far as I can tell the real dependabot can't manage the use case where the code that needs updated is in a `CMakeLists.txt` file. I see an issue requesting this exact use case at https://github.com/dependabot/dependabot-core/issues/7451. That issue has been open for a few years,.