### PR TITLE
Document that mz_zip_tm_to_time_t requires a year-1900 indexed time struct.

### DIFF
--- a/mz_zip.c
+++ b/mz_zip.c
@@ -2669,24 +2669,31 @@ int32_t mz_zip_extrafield_write(void *stream, uint16_t type, uint16_t length) {
 
 /***************************************************************************/
 
+/// This is mostly validating a given time struct is convertible to and from a valid dos date.
+/// This does not however perform a calendar validation (like February 31).
 static int32_t mz_zip_invalid_date(const struct tm *ptm) {
 #define datevalue_in_range(min, max, value) ((min) <= (value) && (value) <= (max))
     return (!datevalue_in_range(0, 127 + 80, ptm->tm_year) || /* 1980-based year, allow 80 extra */
-            !datevalue_in_range(0, 11, ptm->tm_mon) || !datevalue_in_range(1, 31, ptm->tm_mday) ||
-            !datevalue_in_range(0, 23, ptm->tm_hour) || !datevalue_in_range(0, 59, ptm->tm_min) ||
-            !datevalue_in_range(0, 59, ptm->tm_sec));
+            !datevalue_in_range(0, 11, ptm->tm_mon) ||        /* allowing months 0-11 in a year */
+            !datevalue_in_range(1, 31, ptm->tm_mday) ||       /* allowing days 1-31 in a month */
+            !datevalue_in_range(0, 23, ptm->tm_hour) ||       /* allowing hours 0-23 in a day */
+            !datevalue_in_range(0, 59, ptm->tm_min) ||        /* allowing minutes 0-59 in an hour */
+            !datevalue_in_range(0, 59, ptm->tm_sec));         /* allowing seconds 0-59 in a minute */
 #undef datevalue_in_range
 }
 
+/// Returns a year-1900 indexed time struct.
+/// This may produce slightly out-of-range months, hours, minutes, seconds.
+/// This may also produce invalid calendar days (like the 31st of February).
 static void mz_zip_dosdate_to_raw_tm(uint64_t dos_date, struct tm *ptm) {
     uint64_t date = (uint64_t)(dos_date >> 16);
 
-    ptm->tm_mday = (int16_t)(date & 0x1f);
-    ptm->tm_mon = (int16_t)(((date & 0x1E0) / 0x20) - 1);
-    ptm->tm_year = (int16_t)(((date & 0x0FE00) / 0x0200) + 80);
-    ptm->tm_hour = (int16_t)((dos_date & 0xF800) / 0x800);
-    ptm->tm_min = (int16_t)((dos_date & 0x7E0) / 0x20);
-    ptm->tm_sec = (int16_t)(2 * (dos_date & 0x1f));
+    ptm->tm_year = (int16_t)(((date & 0x0FE00) / 0x0200) + 80); /* result in 80..207 */
+    ptm->tm_mon = (int16_t)(((date & 0x1E0) / 0x20) - 1);       /* result in -1..14 */
+    ptm->tm_mday = (int16_t)(date & 0x1f);                      /* result in 0..31 */
+    ptm->tm_hour = (int16_t)((dos_date & 0xF800) / 0x800);      /* result in 0..31 */
+    ptm->tm_min = (int16_t)((dos_date & 0x7E0) / 0x20);         /* result in 0..63 */
+    ptm->tm_sec = (int16_t)(2 * (dos_date & 0x1f));             /* result in 0..62 */
     ptm->tm_isdst = -1;
 }
 
@@ -2711,6 +2718,7 @@ time_t mz_zip_dosdate_to_time_t(uint64_t dos_date) {
 }
 
 time_t mz_zip_tm_to_time_t(struct tm *ptm) {
+    // `ptm->tm_year` must be 1900-indexed.
     return mktime(ptm);
 }
 

--- a/mz_zip.c
+++ b/mz_zip.c
@@ -2669,8 +2669,10 @@ int32_t mz_zip_extrafield_write(void *stream, uint16_t type, uint16_t length) {
 
 /***************************************************************************/
 
-/// This is mostly validating a given time struct is convertible to and from a valid dos date.
-/// This does not however perform a calendar validation (like February 31).
+/**
+ This is mostly validating a given time struct is convertible to and from a valid dos date.
+ This does not however perform a calendar validation (like February 31).
+ */
 static int32_t mz_zip_invalid_date(const struct tm *ptm) {
 #define datevalue_in_range(min, max, value) ((min) <= (value) && (value) <= (max))
     return (!datevalue_in_range(0, 127 + 80, ptm->tm_year) || /* 1980-based year, allow 80 extra */
@@ -2682,9 +2684,11 @@ static int32_t mz_zip_invalid_date(const struct tm *ptm) {
 #undef datevalue_in_range
 }
 
-/// Returns a year-1900 indexed time struct.
-/// This may produce slightly out-of-range months, hours, minutes, seconds.
-/// This may also produce invalid calendar days (like the 31st of February).
+/**
+ Returns a year-1900 indexed time struct.
+ This may produce slightly out-of-range months, hours, minutes, seconds.
+ This may also produce invalid calendar days (like the 31st of February).
+ */
 static void mz_zip_dosdate_to_raw_tm(uint64_t dos_date, struct tm *ptm) {
     uint64_t date = (uint64_t)(dos_date >> 16);
 

--- a/mz_zip.h
+++ b/mz_zip.h
@@ -221,7 +221,7 @@ time_t mz_zip_dosdate_to_time_t(uint64_t dos_date);
 /* Convert dos date/time format to time_t */
 
 time_t mz_zip_tm_to_time_t(struct tm *ptm);
-/* Convert time struct to time_t */
+/* Convert year-1900 indexed time struct to time_t */
 
 int32_t mz_zip_time_t_to_tm(time_t unix_time, struct tm *ptm);
 /* Convert time_t to time struct */

--- a/test/test_compat.cc
+++ b/test/test_compat.cc
@@ -18,7 +18,7 @@
 
 #include <gtest/gtest.h>
 
-#ifdef HAVE_ZLIB
+#if defined(HAVE_ZLIB) || defined(HAVE_LIBCOMP)
 static void test_zip_compat(zipFile zip, const char *filename, int32_t level) {
     int32_t err = ZIP_OK;
     zip_fileinfo file_info;


### PR DESCRIPTION
This is a documentation followup of #930 (and #820).

I wanted to better understand why my experimental fix was working and so I explored the possible values for a dos date, a tm struct and a time_t.

For edge cases:
- a `dos date` is **year 1980 indexed**. A dos date of 0 is around December 1979 due to months being -1 indexed. It doesn't take negative values. Maximum value is dos year 127, so that's roughly year 2108.
- a `tm struct` can have multiple meanings depending on the interpretation of the year ; but as an argument of `mktime`, it's considered to be **year 1900 indexed**. It accepts negative values and as such may go 2 billion years in the past and the future.
- a `time_t` is **year 1970 indexed**. It accepts negative values and can go pretty far both directions.

Now, as I wrote here, a `tm struct` can have multiple meanings depending on the interpretation of the year, and that's why in _some contexts_, it's considered to be **year 0 indexed** (example, the value was 2025). And if you're in such context and want to pass it to `mktime`, then yes, you must first subtract 1900 to the year (here it becomes 125) to convert the struct to be **year 1900 indexed**. But if you were already in the context of being year 1900 indexed (example, the value was 125), then subtracting 1900 (here it becomes -1775) will get you into... **year 3800 indexed**. Which will produce a very negative value of `time_t` (it will produce a time_t equivalent to year 1900-1775 = 125). And since those dates are way too old for the operating system, it will replace them with whatever is the minimal supported date, which was 1980 for @claraSophos.

So what did my fix do?
Well, it passes the `tm struct` to `mz_zip_tm_to_dosdate` where the magic operates: by looking at the range of tm_year and normalising it into `fixed_tm`, it will always produce a valid year-1980 indexed dos date, no matter what was the year origin of the given parameter. Subsequently, it converts it back to a year-1900 indexed time struct, which can finally be passed safely to `mktime`.

So what does the present PR do? I'm simply adding comments saying we require a "year-1900 indexed" parameter for mktime, and that `mz_zip_dosdate_to_raw_tm` just so happen return a "year-1900 indexed" time.

I also made the compat tests compatible with HAVE_LIBCOMP (which is "lib compatibility") where they make the most sense to be tested, and which helped me in this situation.