### PR TITLE
Fixes for `.gitignore` and `test_compat.cc`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,12 @@ third_party/
 
 # IDE
 .vscode
+
+# License files
+LICENSE.dec.aes
+LICENSE.dec.pkcrypt
+LICENSE.enc.aes
+LICENSE.enc.pkcrypt
+
+# test/test_compat.cc can leave compat.zip hanging around
+compat.zip

--- a/test/test_compat.cc
+++ b/test/test_compat.cc
@@ -289,4 +289,13 @@ TEST(compat, unzip64) {
     test_unzip_compat(unzip);
     unzClose(unzip);
 }
+
+/*  Keep this dummy test last in this file.
+    It's purpose is to delete "compat.zip" after all other tests have run.
+*/
+
+TEST(compat, final) {
+    if (mz_os_file_exists("compat.zip") != MZ_OK)
+        mz_os_unlink("compat.zip");
+}
 #endif


### PR DESCRIPTION
Somehow I managed to delete the original PR I used for this change -- see #939 

To summarise, this PR does the following

Update `.gitignore` to include these license files
```
LICENSE.dec.aes
LICENSE.dec.pkcrypt
LICENSE.enc.aes
LICENSE.enc.pkcrypt
```

`test_compat.cc` doesn't delete `compat.zip` on completion - change gets the test harness to delete it.