### PR TITLE
Compiler warning: use of `mktemp` is dangerous. Fixes #956

### DIFF
--- a/mz_os_posix.c
+++ b/mz_os_posix.c
@@ -383,7 +383,7 @@ int32_t mz_os_get_temp_path(char *path, int32_t max_path, const char *prefix) {
     if (result < 0 || result >= max_path)
         return MZ_BUF_ERROR;
 
-    free(temp_path) ;
+    free(temp_path);
     return MZ_OK;
 }
 

--- a/mz_os_posix.c
+++ b/mz_os_posix.c
@@ -389,7 +389,7 @@ int32_t mz_os_get_temp_path(char *path, int32_t max_path, const char *prefix) {
     /* Use current time for the filename                */
     result = snprintf(path, max_path, "%s/%lux", temp_path, time(NULL));
     if (result < 0 || result >= max_path) {
-        rmdir(temp_path);
+        rmdir(temp_path);  // clean up the created directory
         free(temp_path);
         return MZ_BUF_ERROR;
     }

--- a/mz_os_posix.c
+++ b/mz_os_posix.c
@@ -352,8 +352,8 @@ int32_t mz_os_read_symlink(const char *path, char *target_path, int32_t max_targ
 
 int32_t mz_os_get_temp_path(char *path, int32_t max_path, const char *prefix) {
     const char *tmp_dir = NULL;
+    char *temp_path = (char *)calloc(max_path, sizeof(char));
     int32_t result = 0;
-    char temp_path[max_path];
 
     if (!path || max_path <= 0)
         return MZ_PARAM_ERROR;

--- a/mz_os_posix.c
+++ b/mz_os_posix.c
@@ -383,6 +383,7 @@ int32_t mz_os_get_temp_path(char *path, int32_t max_path, const char *prefix) {
     if (result < 0 || result >= max_path)
         return MZ_BUF_ERROR;
 
+    free(temp_path) ;
     return MZ_OK;
 }
 

--- a/mz_os_posix.c
+++ b/mz_os_posix.c
@@ -378,7 +378,8 @@ int32_t mz_os_get_temp_path(char *path, int32_t max_path, const char *prefix) {
         return MZ_INTERNAL_ERROR;
 
     /* Create a filename inside the temporary directory */
-    result = snprintf(path, max_path, "%s/f", temp_path);
+    /* Use current time for the filename                */
+    result = snprintf(path, max_path, "%s/%lux", temp_path, time(NULL));
     if (result < 0 || result >= max_path)
         return MZ_BUF_ERROR;
 

--- a/mz_os_posix.c
+++ b/mz_os_posix.c
@@ -366,10 +366,6 @@ int32_t mz_os_get_temp_path(char *path, int32_t max_path, const char *prefix) {
     if (!tmp_dir)
         tmp_dir = "/tmp";
 
-    /* Check for no environment variable set at all */
-    if (!tmp_dir)
-        return MZ_INTERNAL_ERROR;
-
     /* Build template path for mkdtemp: <tmp_dir>/<prefix>XXXXXX */
     result = snprintf(temp_path, max_path, "%s/%sXXXXXX", tmp_dir, prefix ? prefix : "");
     if (result < 0 || result >= max_path)

--- a/mz_os_posix.c
+++ b/mz_os_posix.c
@@ -352,7 +352,7 @@ int32_t mz_os_read_symlink(const char *path, char *target_path, int32_t max_targ
 
 int32_t mz_os_get_temp_path(char *path, int32_t max_path, const char *prefix) {
     const char *tmp_dir = NULL;
-    char *temp_path = (char *)calloc(max_path, sizeof(char));
+    char *temp_path;
     int32_t result = 0;
 
     if (!path || max_path <= 0)
@@ -367,6 +367,10 @@ int32_t mz_os_get_temp_path(char *path, int32_t max_path, const char *prefix) {
         tmp_dir = "/tmp";
 
     /* Build template path for mkdtemp: <tmp_dir>/<prefix>XXXXXX */
+    temp_path = (char *)calloc(max_path, sizeof(char));
+    if (!temp_path)
+        return MZ_MEM_ERROR;
+
     result = snprintf(temp_path, max_path, "%s/%sXXXXXX", tmp_dir, prefix ? prefix : "");
     if (result < 0 || result >= max_path) {
         free(temp_path);
@@ -385,6 +389,7 @@ int32_t mz_os_get_temp_path(char *path, int32_t max_path, const char *prefix) {
     /* Use current time for the filename                */
     result = snprintf(path, max_path, "%s/%lux", temp_path, time(NULL));
     if (result < 0 || result >= max_path) {
+        rmdir(temp_path);
         free(temp_path);
         return MZ_BUF_ERROR;
     }

--- a/mz_os_posix.c
+++ b/mz_os_posix.c
@@ -368,20 +368,26 @@ int32_t mz_os_get_temp_path(char *path, int32_t max_path, const char *prefix) {
 
     /* Build template path for mkdtemp: <tmp_dir>/<prefix>XXXXXX */
     result = snprintf(temp_path, max_path, "%s/%sXXXXXX", tmp_dir, prefix ? prefix : "");
-    if (result < 0 || result >= max_path)
+    if (result < 0 || result >= max_path) {
+        free(temp_path);
         return MZ_BUF_ERROR;
+    }
 
     /* Create a temporary directory.
        mkdtemp replaces XXXXXX with unique characters
     */
-    if (!mkdtemp(temp_path))
+    if (!mkdtemp(temp_path)) {
+        free(temp_path);
         return MZ_INTERNAL_ERROR;
+    }
 
     /* Create a filename inside the temporary directory */
     /* Use current time for the filename                */
     result = snprintf(path, max_path, "%s/%lux", temp_path, time(NULL));
-    if (result < 0 || result >= max_path)
+    if (result < 0 || result >= max_path) {
+        free(temp_path);
         return MZ_BUF_ERROR;
+    }
 
     free(temp_path);
     return MZ_OK;

--- a/mz_os_posix.c
+++ b/mz_os_posix.c
@@ -326,7 +326,7 @@ int32_t mz_os_is_symlink(const char *path) {
 int32_t mz_os_make_symlink(const char *path, const char *target_path) {
 #if defined(NO_SYMLINK)
     return MZ_SUPPORT_ERROR;
-#else	
+#else
     if (symlink(target_path, path) != 0)
         return MZ_INTERNAL_ERROR;
     return MZ_OK;
@@ -353,6 +353,7 @@ int32_t mz_os_read_symlink(const char *path, char *target_path, int32_t max_targ
 int32_t mz_os_get_temp_path(char *path, int32_t max_path, const char *prefix) {
     const char *tmp_dir = NULL;
     int32_t result = 0;
+    char temp_path[max_path];
 
     if (!path || max_path <= 0)
         return MZ_PARAM_ERROR;
@@ -365,14 +366,25 @@ int32_t mz_os_get_temp_path(char *path, int32_t max_path, const char *prefix) {
     if (!tmp_dir)
         tmp_dir = "/tmp";
 
-    /* Build template path for mktemp: <tmp_dir>/<prefix>XXXXXX */
-    result = snprintf(path, max_path, "%s/%sXXXXXX", tmp_dir, prefix ? prefix : "");
+    /* Check for no environment variable set at all */
+    if (!tmp_dir)
+        return MZ_INTERNAL_ERROR;
+
+    /* Build template path for mkdtemp: <tmp_dir>/<prefix>XXXXXX */
+    result = snprintf(temp_path, max_path, "%s/%sXXXXXX", tmp_dir, prefix ? prefix : "");
     if (result < 0 || result >= max_path)
         return MZ_BUF_ERROR;
 
-    /* mktemp replaces XXXXXX with unique characters */
-    if (!mktemp(path))
+    /* Create a temporary directory.
+       mkdtemp replaces XXXXXX with unique characters
+    */
+    if (!mkdtemp(temp_path))
         return MZ_INTERNAL_ERROR;
+
+    /* Create a filename inside the temporary directory */
+    result = snprintf(path, max_path, "%s/f", temp_path);
+    if (result < 0 || result >= max_path)
+        return MZ_BUF_ERROR;
 
     return MZ_OK;
 }


### PR DESCRIPTION
Silence the compiler warning below by using `mkdtemp` instead of `mktemp`
```
57%] Linking C executable minigzip
/usr/bin/ld: libminizip.a(mz_os_posix.c.o): in function `mz_os_get_temp_path':
/home/runner/work/minizip-ng/minizip-ng/mz_os_posix.c:374:(.text+0x1023): warning: the use of `mktemp' is dangerous, better use `mkstemp' or `mkdtemp'
[ 57%] Built target minigzip_cli
[ 60%] Building C object CMakeFiles/minizip_cli.dir/minizip.c.o
[ 62%] Linking C executable minizip
/usr/bin/ld: libminizip.a(mz_os_posix.c.o): in function `mz_os_get_temp_path':
/home/runner/work/minizip-ng/minizip-ng/mz_os_posix.c:374:(.text+0x1023): warning: the use of `mktemp' is dangerous, better use `mkstemp' or `mkdtemp'
```