### PR TITLE
Remove calls to `add_subdirectory` in `CMakeLists.txt` for lzma & zlib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -226,9 +226,6 @@ if(MZ_ZLIB)
 
         clone_repo(zlib https://github.com/zlib-ng/zlib-ng stable)
 
-        # Don't automatically add all targets to the solution
-        add_subdirectory(${ZLIB_SOURCE_DIR} ${ZLIB_BINARY_DIR} EXCLUDE_FROM_ALL)
-
         list(APPEND MINIZIP_INC ${ZLIB_SOURCE_DIR})
         list(APPEND MINIZIP_INC ${ZLIB_BINARY_DIR})
 
@@ -343,9 +340,6 @@ if(MZ_LZMA)
         set(BUILD_TESTING OFF CACHE BOOL "Build lzma tests" FORCE)
 
         clone_repo(liblzma https://github.com/tukaani-project/xz master)
-
-        # Don't automatically add all targets to the solution
-        add_subdirectory(${LIBLZMA_SOURCE_DIR} ${LIBLZMA_BINARY_DIR} EXCLUDE_FROM_ALL)
 
         list(APPEND MINIZIP_INC ${LIBLZMA_SOURCE_DIR}/src/liblzma/api)
         list(APPEND MINIZIP_DEP liblzma)


### PR DESCRIPTION
These are the two errors in the Windows build:

```
 * INSTALL_UTILS, Copy minigzip and minideflate during install

CMake Error at CMakeLists.txt:230 (add_subdirectory):
  The binary directory

    D:/a/minizip-ng/minizip-ng/_deps/zlib-build

  is already used to build a source directory.  It cannot be used to build
  source directory

    D:/a/minizip-ng/minizip-ng/third_party/zlib

  Specify a unique binary directory name.
```

```
CMake Error at CMakeLists.txt:348 (add_subdirectory):
  The binary directory

    D:/a/minizip-ng/minizip-ng/_deps/liblzma-build

  is already used to build a source directory.  It cannot be used to build
  source directory

    D:/a/minizip-ng/minizip-ng/third_party/liblzma

  Specify a unique binary directory name.


-- Using PPMD
```

The lines in question that cmake is complaining about are both calls to `add_subdirectory`
```
        add_subdirectory(${ZLIB_SOURCE_DIR} ${ZLIB_BINARY_DIR} EXCLUDE_FROM_ALL)

        add_subdirectory(${LIBLZMA_SOURCE_DIR} ${LIBLZMA_BINARY_DIR} EXCLUDE_FROM_ALL)
```

The documentation for `FetchContent_MakeAvailable` from https://cmake.org/cmake/help/v3.15/module/FetchContent.html says:



> **FetchContent_MakeAvailable( <name1> [<name2>...] )**
> 
> This command implements the common pattern typically needed for most dependencies. It iterates over each of the named dependencies in turn and for each one it loosely follows the same [canonical pattern](https://cmake.org/cmake/help/v3.15/module/FetchContent.html#fetch-content-canonical-pattern) as presented at the beginning of this section. One small difference to that pattern is that it will only call [add_subdirectory()](https://cmake.org/cmake/help/v3.15/command/add_subdirectory.html#command:add_subdirectory) on the populated content if there is a CMakeLists.txt file in its top level source directory. This allows the command to be used for dependencies that make downloaded content available at a known location but which do not need or support being added directly to the build.

Note the part about `FetchContent_MakeAvailable` calling `add_subdirectory`.

Removing the LZMA and ZLIB calls to `add_subdirectory`  from `CMakeLists.txt` allows `build.yml` to complete the generation of the project files and I'm seeing the building of the executable/libraries operating normally on Windows.

On my local setup that is enough for the test harness to pass 100% on Windows.

On GitHub all the erase tests are failing with a -111 error

```
Test project D:/a/minizip-ng/minizip-ng
        Start   1: raw-zip-generic
  1/246 Test   #1: raw-zip-generic ..................   Passed    0.02 sec
        Start   2: raw-list-generic
  2/246 Test   #2: raw-list-generic .................   Passed    0.01 sec
        Start   3: raw-unzip-generic
  3/246 Test   #3: raw-unzip-generic ................   Passed    0.02 sec
        Start   4: raw-append-generic
  4/246 Test   #4: raw-append-generic ...............   Passed    0.01 sec
        Start   5: raw-append-unzip-generic
  5/246 Test   #5: raw-append-unzip-generic .........   Passed    0.02 sec
        Start   6: raw-erase-generic
  6/246 Test   #6: raw-erase-generic ................   Passed    0.01 sec
        Start   7: raw-erase-unzip-generic
  7/246 Test   #7: raw-erase-unzip-generic ..........***Failed    0.01 sec
minizip-ng 4.1.0 - https://github.com/zlib-ng/minizip-ng
---------------------------------------------------
-x -o -d D:/a/minizip-ng/minizip-ng/Testing/Temporary/raw-generic D:/a/minizip-ng/minizip-ng/Testing/Temporary/raw-generic.zip 
Archive D:/a/minizip-ng/minizip-ng/Testing/Temporary/raw-generic.zip
Error -111 opening archive D:/a/minizip-ng/minizip-ng/Testing/Temporary/raw-generic.zip
...
```
