### PR TITLE
Replace ZLIB_ENABLE_TESTS with BUILD_TESTING

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -218,7 +218,7 @@ if(MZ_ZLIB)
         set(PC_PRIVATE_DEPS "zlib")
         set(ZLIB_COMPAT ON)
     elseif(MZ_FETCH_LIBS)
-        set(ZLIB_ENABLE_TESTS OFF CACHE BOOL "Build zlib-ng tests" FORCE)
+        set(BUILD_TESTING OFF CACHE BOOL "Build zlib-ng tests" FORCE)
 
         clone_repo(zlib https://github.com/zlib-ng/zlib-ng stable)
 


### PR DESCRIPTION
Sorts out this warning
```
-- Fetching zlib https://github.com/zlib-ng/zlib-ng stable
-- Using CMake version 3.31.6-msvc6
-- ZLIB_HEADER_VERSION: 1.3.1
-- ZLIBNG_HEADER_VERSION: 2.3.3
CMake Deprecation Warning at third_party/zlib/CMakeLists.txt:54 (message):
  ZLIB_ENABLE_TESTS is deprecated.  Please use BUILD_TESTING instead.
-- Arch detected: 'x86_64'
...

-- The following features have been disabled:

 * ZLIB_SYMBOL_PREFIX, Publicly exported symbols DO NOT have a custom prefix
 * ZLIB_COMPAT, Compile with zlib compatible API
 * BUILD_TESTING, Build test binaries
```