### PR TITLE
Fix MSVC workflows

### DIFF
--- a/minizip.c
+++ b/minizip.c
@@ -532,11 +532,15 @@ int32_t minizip_erase(const char *src_path, const char *target_path, int32_t arg
             if (mz_os_file_exists(bak_path) == MZ_OK)
                 mz_os_unlink(bak_path);
 
-            if (mz_os_rename(src_path, bak_path) != MZ_OK)
+            err = MZ_OK;
+
+            if ((err = mz_os_rename(src_path, bak_path)) != MZ_OK)
                 printf("Error backing up archive before replacing %s\n", bak_path);
 
-            if (mz_os_rename(tmp_path, src_path) != MZ_OK)
+            if ((err = mz_os_rename(tmp_path, src_path)) != MZ_OK)
                 printf("Error replacing archive with temp %s\n", tmp_path);
+
+            return err;
         }
 
         return MZ_OK;

--- a/mz_os_win32.c
+++ b/mz_os_win32.c
@@ -134,7 +134,7 @@ int32_t mz_os_rename(const char *source_path, const char *target_path) {
 
     if (err == MZ_OK) {
 #if _WIN32_WINNT >= _WIN32_WINNT_WINXP
-        result = MoveFileExW(source_path_wide, target_path_wide, MOVEFILE_WRITE_THROUGH);
+        result = MoveFileExW(source_path_wide, target_path_wide, MOVEFILE_WRITE_THROUGH|MOVEFILE_COPY_ALLOWED);
 #else
         result = MoveFileW(source_path_wide, target_path_wide);
 #endif

--- a/mz_os_win32.c
+++ b/mz_os_win32.c
@@ -134,7 +134,7 @@ int32_t mz_os_rename(const char *source_path, const char *target_path) {
 
     if (err == MZ_OK) {
 #if _WIN32_WINNT >= _WIN32_WINNT_WINXP
-        result = MoveFileExW(source_path_wide, target_path_wide, MOVEFILE_WRITE_THROUGH|MOVEFILE_COPY_ALLOWED);
+        result = MoveFileExW(source_path_wide, target_path_wide, MOVEFILE_WRITE_THROUGH | MOVEFILE_COPY_ALLOWED);
 #else
         result = MoveFileW(source_path_wide, target_path_wide);
 #endif


### PR DESCRIPTION
The Windows MSVC workflow failures expose two different issues. 


The root cause for first failure is triggered on GitHub, but not locally on my setup. This is down to the use of multiple Windows volumes on GitHub. My setup is all on `C:`

Below is the verbose output from the `raw-erase-generic` test that shows a side-effect of the error

```
test 8 
Start 8: raw-erase-generic 
8: Test command: D:\a\minizip-ng\minizip-ng\Release\minizip.exe "-o" "-e" "D:/a/minizip-ng/minizip-ng/Testing/Temporary/raw-generic.zip" "test.c" "test.h" 
8: Working Directory: D:/a/minizip-ng/minizip-ng/test 
8: Test timeout computed to be: 10000000 
8: minizip-ng 4.1.0 - https://github.com/zlib-ng/minizip-ng 
8: --------------------------------------------------- 
8: -o -e D:/a/minizip-ng/minizip-ng/Testing/Temporary/raw-generic.zip test.c test.h 


8: Error replacing archive with temp C:\Users\RUNNER~1\AppData\Local\Temp\mz_D98A.tmp 
8/10 Test #8: raw-erase-generic ................ Passed 0.01 sec
```
The zip file lives on `C:`, but the temp file on `D:`. 

The code to do the replace ultimately calls `MoveFileExW` to do the rename/replace.

Unfortunately `MoveFileExW` doesn't allow cross-volume moves/copies by default -- for that it needs the `MOVEFILE_COPY_ALLOWED` flag, as below

```C
        result = MoveFileExW(source_path_wide, target_path_wide, MOVEFILE_WRITE_THROUGH|MOVEFILE_COPY_ALLOWED);
```

Adding that flag sorts the issue.

The second issue this exposes is that  `raw-erase-generic`  test didn't fail. 

```
8: Error replacing archive with temp C:\Users\RUNNER~1\AppData\Local\Temp\mz_D98A.tmp 
8/10 Test #8: raw-erase-generic ................ Passed 0.01 sec
```


The issue was only highlighted because the next test in the sequence, `raw-erase-unzip-generic` failed because the input zip file didn't exist.

That's down to this section of code in `minizip.c`
```C
    if (err == MZ_END_OF_LIST) {
        if (!target_path) {
            /* Swap original archive with temporary archive, backup old archive if possible */
            strncpy(bak_path, src_path, sizeof(bak_path) - 1);
            bak_path[sizeof(bak_path) - 1] = 0;
            strncat(bak_path, ".bak", sizeof(bak_path) - strlen(bak_path) - 1);

            if (mz_os_file_exists(bak_path) == MZ_OK)
                mz_os_unlink(bak_path);

            if (mz_os_rename(src_path, bak_path) != MZ_OK)
                printf("Error backing up archive before replacing %s\n", bak_path);

            if (mz_os_rename(tmp_path, src_path) != MZ_OK)
                printf("Error replacing archive with temp %s\n", tmp_path);
        }

        return MZ_OK;
    }
```

There are two failure conditions that are reported, but  `err` doesn't get set to an error value. This PR sorts that issue as well