### PR TITLE
Fix integer overflow in split stream write for disk sizes > 2GB

### DIFF
--- a/mz_strm_split.c
+++ b/mz_strm_split.c
@@ -255,7 +255,7 @@ int32_t mz_stream_split_write(void *stream, const void *buf, int32_t size) {
     int32_t written = 0;
     int32_t bytes_left = size;
     int32_t bytes_to_write = 0;
-    int32_t bytes_avail = 0;
+    int64_t bytes_avail = 0;
     int32_t number_disk = -1;
     int32_t err = MZ_OK;
     const uint8_t *buf_ptr = (const uint8_t *)buf;
@@ -279,7 +279,7 @@ int32_t mz_stream_split_write(void *stream, const void *buf, int32_t size) {
             }
 
             if (split->number_disk != -1) {
-                bytes_avail = (int32_t)(split->disk_size - split->total_out_disk);
+                bytes_avail = split->disk_size - split->total_out_disk;
                 if (bytes_to_write > bytes_avail)
                     bytes_to_write = bytes_avail;
             }


### PR DESCRIPTION
In `mz_stream_split_write()`, the `bytes_avail` variable was declared as `int32_t` and the 64-bit result of `(disk_size - total_out_disk)` was explicitly cast to `int32_t`. When the split disk size exceeds `INT32_MAX` (~2GB), this truncation causes `bytes_avail` to wrap to a negative value, producing incorrect write sizes and ultimately returning `MZ_WRITE_ERROR`. This fix changes `bytes_avail` to `int64_t` and removes the truncating cast, allowing split sizes well beyond 50GB to work correctly.

Fixes #961

Summary generated with Claude Code.