### PR TITLE
Restore ability to prefer OpenSSL over BCrypt on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,7 @@ option(MZ_FORCE_FETCH_LIBS "Enables fetching third-party libraries always" OFF)
 # Encryption support options
 option(MZ_PKCRYPT "Enables PKWARE traditional encryption" ON)
 option(MZ_WZAES "Enables WinZIP AES encryption" ON)
-cmake_dependent_option(MZ_OPENSSL "Enables OpenSSL for encryption" ON "UNIX" OFF)
+option(MZ_OPENSSL "Enables OpenSSL for encryption" ${UNIX})
 cmake_dependent_option(MZ_LIBBSD "Builds with libbsd crypto random" ON "UNIX" OFF)
 # Character conversion options
 option(MZ_ICONV "Enables iconv for string encoding conversion" ON)


### PR DESCRIPTION
One may prefer to use OpenSSL instead of BCrypt even on Windows, for example, for consistency in cross-platform projects, performance reasons etc.

The current CMakeLists.txt fully support such configurations, except that commit abc80d1049ae ("Clean up CMake options and add feature_info for MZ_BCRYPT") make the MZ_OPENSSL option not available on Windows.

Restore the pre-commit behaviour. The default configuration will behave the same way as before the change (use BCrypt by default and don't test for OpenSSL on Windows).

Tested on Windows 11 w/clang-cl.