### PR TITLE
Fix two bugs causing premature exiting the PPMd decompression

### DIFF
--- a/mz_strm_ppmd.c
+++ b/mz_strm_ppmd.c
@@ -309,18 +309,16 @@ int32_t mz_stream_ppmd_read(void *stream, void *buf, int32_t size) {
     mz_stream_ppmd *ppmd = (mz_stream_ppmd *)stream;
     uint8_t *next_out = buf;
     int32_t avail_out;
-    int32_t avail_in = sizeof(ppmd->buffer);
+    int64_t start_in = ppmd->total_in;
+    int64_t avail_in = (ppmd->max_total_in > 0 ? ppmd->max_total_in : INT64_MAX) - start_in;
     int sym = 0;
     int32_t written = 0;
 
     if (ppmd->end_stream)
         return MZ_OK;
 
-    if (ppmd->max_total_in > 0 && avail_in > (ppmd->max_total_in - ppmd->total_in))
-        avail_in = (int32_t)(ppmd->max_total_in - ppmd->total_in);
-
     /* Decode input to fill the output buffer. */
-    for (avail_out = size; avail_out > 0 && avail_in > 0; avail_out--, avail_in--) {
+    for (avail_out = size; avail_out > 0 && avail_in > (ppmd->total_in - start_in); avail_out--) {
         sym = Ppmd8_DecodeSymbol(&ppmd->ppmd8);
 
         /* There are two ways to terminate the loop early:

--- a/mz_strm_ppmd.c
+++ b/mz_strm_ppmd.c
@@ -150,6 +150,11 @@ static Byte reader(void *p) {
     uint8_t b;
     int32_t status;
 
+    if (ppmd->max_total_in > 0 && ppmd->total_in >= ppmd->max_total_in) {
+        ppmd->error = MZ_STREAM_ERROR;
+        return 0;
+    }
+
     if ((status = mz_stream_read_uint8((mz_stream_ppmd *)ppmd->stream.base, &b)) != MZ_OK) {
         ppmd->error = status;
         b = 0;


### PR DESCRIPTION
1. PPMd doesn't use a buffer to read input data, it reads data byte-by-byte, and it doesn't have a loop to process the whole requested size buffer-by-buffer, but still has a cap of maximum input bytes set to `INT16_MAX`. As a result, the decompression function never decodes more bytes than this number and exits.
2. The byte-by-byte decoding loop decrements `avail_in` together with `avail_out`, but 1 byte of compressed data doesn't mean 1 byte of compressed data. This results in that the decompression ends after writing `avail_in` of **decompressed** data, which is always less than the requested size.

Fix the first one by removing the cap of `INT16_MAX` and using the real boundaries (`max_avail_in`) capped to `INT32_MAX` just in case (the requested size is of `int32`, but `max_avail_in` is of `int64_t` and can be bigger than the former).
Fix the second one by tracking how many **compressed** bytes were actually read and exit only when the actual limit is exhausted.

This removes the need of calling `mz_zip{,_reader}_entry_read()` in a loop when the ZIP is compressed with PPMd and the caller wants to read the whole file or a chunk larger than the compressed size (or `INT16_MAX`).

+ a bonus from CodeRabbit to make sure the LZMA SDK code won't read past the limit.

Tested on Windows w/clang-cl and a PPMd-compressed ZIP containing up to 700 Kb -sized files.