### PR TITLE
test: skip AES-GCM test when build doesn't support it

### DIFF
--- a/test/test_crypt.cc
+++ b/test/test_crypt.cc
@@ -258,7 +258,12 @@ TEST(crypt, aes128_gcm) {
     aes = mz_crypt_aes_create();
     ASSERT_NE(aes, nullptr);
     mz_crypt_aes_set_mode(aes, MZ_AES_MODE_GCM);
-    EXPECT_EQ(mz_crypt_aes_set_encrypt_key(aes, key, key_length, iv, iv_length), MZ_OK);
+    int32_t set_key_err = mz_crypt_aes_set_encrypt_key(aes, key, key_length, iv, iv_length);
+    if (set_key_err == MZ_SUPPORT_ERROR) {
+        mz_crypt_aes_delete(&aes);
+        GTEST_SKIP() << "AES-GCM not supported in this build";
+    }
+    EXPECT_EQ(set_key_err, MZ_OK);
     EXPECT_EQ(mz_crypt_aes_encrypt(aes, aad, aad_length, buf, test_length), test_length);
     EXPECT_EQ(mz_crypt_aes_encrypt_final(aes, buf + test_length, test_length - 1, tag, sizeof(tag)), test_length - 1);
     mz_crypt_aes_delete(&aes);


### PR DESCRIPTION
On macOS the Apple crypto backend in mz_crypt_apple.c defaults MZ_TARGET_APPSTORE to 1 because the GCM CommonCrypto APIs (CCCryptorGCMAddIV, CCCryptorGCMEncrypt, ...) are private and Apple's App Store reviewers reject binaries that link against them. In that mode mz_crypt_aes_set_key correctly returns MZ_SUPPORT_ERROR for AES-GCM, but test_crypt.cc was checking unconditionally for MZ_OK and the crypt.aes128_gcm case showed up as a failure on every default-configured macOS run. Detect the support error like the existing Windows-XP guard does and GTEST_SKIP() the case so the default build stays green; with -DMZ_TARGET_APPSTORE=0 the test still passes end-to-end.