### PR TITLE
compat: add unzGetCurrentFileZStreamPos64

### DIFF
--- a/compat/unzip.c
+++ b/compat/unzip.c
@@ -629,6 +629,13 @@ int unzSetOffset64(unzFile file, int64_t pos) {
     return (int)mz_zip_goto_entry(compat->handle, pos);
 }
 
+uint64_t unzGetCurrentFileZStreamPos64(unzFile file) {
+    mz_unzip_compat *compat = (mz_unzip_compat *)file;
+    if (!compat || mz_zip_entry_is_open(compat->handle) != MZ_OK)
+        return 0;
+    return (uint64_t)compat->entry_pos;
+}
+
 int unzGetLocalExtrafield(unzFile file, void *buf, unsigned int len) {
     mz_unzip_compat *compat = (mz_unzip_compat *)file;
     mz_zip_file *file_info = NULL;

--- a/compat/unzip.h
+++ b/compat/unzip.h
@@ -217,6 +217,7 @@ ZEXPORT int64_t unzGetOffset64(unzFile file);
 ZEXPORT unsigned long unzGetOffset(unzFile file);
 ZEXPORT int unzSetOffset64(unzFile file, int64_t pos);
 ZEXPORT int unzSetOffset(unzFile file, unsigned long pos);
+ZEXPORT uint64_t unzGetCurrentFileZStreamPos64(unzFile file);
 ZEXPORT int32_t unztell(unzFile file);
 ZEXPORT uint64_t unztell64(unzFile file);
 ZEXPORT int unzeof(unzFile file);


### PR DESCRIPTION
Adds the `unzGetCurrentFileZStreamPos64` accessor from the original minizip to the compat layer. The function returns the absolute offset in the underlying file where the currently-open entry's compressed data begins, and is depended on by chromium and other downstreams that swap zlib+minizip for zlib-ng+minizip-ng (see #848). The compat layer already captures this position into `entry_pos` during `unzOpenCurrentFile3` for STORE-method seek support, so the implementation is a thin getter gated on `mz_zip_entry_is_open` to match the original's "return 0 when no entry is open" behavior.