### PR TITLE
docs: update memory stream test link

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -203,7 +203,7 @@ mz_zip_delete(&zip_handle);
 mz_stream_mem_delete(&mem_stream);
 ```
 
-For a complete example, see test_stream_mem() in [test.c](https://github.com/nmoinvaz/minizip/blob/master/test/test.c).
+For examples of memory stream usage, see [test/test_stream.cc](https://github.com/zlib-ng/minizip-ng/blob/develop/test/test_stream.cc).
 
 ### Buffered Stream
 


### PR DESCRIPTION
## Summary

Updates the memory stream example reference to point at the current `test/test_stream.cc` file instead of the old `nmoinvaz/minizip` `test.c` link.

Closes #996.

## Testing

Not run; documentation-only link update.