### PR TITLE
Fix for issue744: Added support for int64_t for mz_strm_mem

### DIFF
--- a/compat/ioapi.c
+++ b/compat/ioapi.c
@@ -74,6 +74,15 @@ static int64_t mz_stream_ioapi_read(void *stream, void *buf, int64_t size) {
     mz_stream_ioapi *ioapi = (mz_stream_ioapi *)stream;
     read_file_func zread = NULL;
     void *opaque = NULL;
+    unsigned long to_read;
+    unsigned long bytes_read;
+    int64_t total_read = 0;
+    
+    if (size < 0)
+        return MZ_PARAM_ERROR;
+
+    if (size == 0)
+        return 0;
 
     if (mz_stream_ioapi_is_open(stream) != MZ_OK)
         return MZ_OPEN_ERROR;
@@ -87,14 +96,36 @@ static int64_t mz_stream_ioapi_read(void *stream, void *buf, int64_t size) {
     } else
         return MZ_PARAM_ERROR;
 
-    return (int32_t)zread(opaque, ioapi->handle, buf, size);
+    //Because zread expects unsigned long in size which differs on different system
+    //Need to clamp existed data and feed it in chuncks
+    while (total_read < size)
+    {
+        to_read = (size - total_read > ULONG_MAX) ? ULONG_MAX : (unsigned long) (size - total_read);
+        bytes_read = zread(opaque, ioapi->handle, (uint8_t *)buf + total_read, to_read);
+
+        if (bytes_read <= 0)
+            break;
+
+        total_read += bytes_read;
+
+    }
+
+    return total_read;
 }
 
 static int64_t mz_stream_ioapi_write(void *stream, const void *buf, int64_t size) {
     mz_stream_ioapi *ioapi = (mz_stream_ioapi *)stream;
     write_file_func zwrite = NULL;
-    int32_t written = 0;
     void *opaque = NULL;
+    int64_t total_written = 0;
+    unsigned long to_write;
+    unsigned long bytes_written;
+
+    if (size < 0)
+        return MZ_PARAM_ERROR;
+
+    if (size == 0)
+        return 0;
 
     if (mz_stream_ioapi_is_open(stream) != MZ_OK)
         return MZ_OPEN_ERROR;
@@ -108,8 +139,21 @@ static int64_t mz_stream_ioapi_write(void *stream, const void *buf, int64_t size
     } else
         return MZ_PARAM_ERROR;
 
-    written = (int32_t)zwrite(opaque, ioapi->handle, buf, size);
-    return written;
+    //Because zwrite expects unsigned long in size which differs on different system
+    //Need to clamp existed data and feed it in chuncks
+    while (total_written < size)
+    {
+        to_write = (size - total_written > ULONG_MAX) ? ULONG_MAX : (unsigned long) (size - to_write);
+        bytes_written = zwrite(opaque, ioapi->handle, (const uint8_t *)buf + total_written, to_write);
+
+        if (bytes_written <= 0)
+            break;
+
+        total_written += bytes_written;
+
+    }
+
+    return total_written;
 }
 
 static int64_t mz_stream_ioapi_tell(void *stream) {
@@ -136,6 +180,8 @@ static int64_t mz_stream_ioapi_seek(void *stream, int64_t offset, int32_t origin
         if (ioapi->filefunc64.zseek64_file(ioapi->filefunc64.opaque, ioapi->handle, offset, origin) != 0)
             return MZ_INTERNAL_ERROR;
     } else if (ioapi->filefunc.zseek_file) {
+        if (offset < INT32_MIN || offset > INT32_MAX)
+            return MZ_PARAM_ERROR;
         if (ioapi->filefunc.zseek_file(ioapi->filefunc.opaque, ioapi->handle, (int32_t)offset, origin) != 0)
             return MZ_INTERNAL_ERROR;
     } else

--- a/compat/ioapi.c
+++ b/compat/ioapi.c
@@ -143,7 +143,7 @@ static int64_t mz_stream_ioapi_write(void *stream, const void *buf, int64_t size
     //Need to clamp existed data and feed it in chuncks
     while (total_written < size)
     {
-        to_write = (size - total_written > ULONG_MAX) ? ULONG_MAX : (unsigned long) (size - to_write);
+        to_write = (size - total_written > ULONG_MAX) ? ULONG_MAX : (unsigned long) (size - total_written);
         bytes_written = zwrite(opaque, ioapi->handle, (const uint8_t *)buf + total_written, to_write);
 
         if (bytes_written <= 0)

--- a/compat/ioapi.c
+++ b/compat/ioapi.c
@@ -15,10 +15,10 @@ typedef struct mz_stream_ioapi_s {
 
 static int32_t mz_stream_ioapi_open(void *stream, const char *path, int32_t mode);
 static int32_t mz_stream_ioapi_is_open(void *stream);
-static int32_t mz_stream_ioapi_read(void *stream, void *buf, int32_t size);
-static int32_t mz_stream_ioapi_write(void *stream, const void *buf, int32_t size);
+static int64_t mz_stream_ioapi_read(void *stream, void *buf, int64_t size);
+static int64_t mz_stream_ioapi_write(void *stream, const void *buf, int64_t size);
 static int64_t mz_stream_ioapi_tell(void *stream);
-static int32_t mz_stream_ioapi_seek(void *stream, int64_t offset, int32_t origin);
+static int64_t mz_stream_ioapi_seek(void *stream, int64_t offset, int32_t origin);
 static int32_t mz_stream_ioapi_close(void *stream);
 static int32_t mz_stream_ioapi_error(void *stream);
 
@@ -70,7 +70,7 @@ static int32_t mz_stream_ioapi_is_open(void *stream) {
     return MZ_OK;
 }
 
-static int32_t mz_stream_ioapi_read(void *stream, void *buf, int32_t size) {
+static int64_t mz_stream_ioapi_read(void *stream, void *buf, int64_t size) {
     mz_stream_ioapi *ioapi = (mz_stream_ioapi *)stream;
     read_file_func zread = NULL;
     void *opaque = NULL;
@@ -90,7 +90,7 @@ static int32_t mz_stream_ioapi_read(void *stream, void *buf, int32_t size) {
     return (int32_t)zread(opaque, ioapi->handle, buf, size);
 }
 
-static int32_t mz_stream_ioapi_write(void *stream, const void *buf, int32_t size) {
+static int64_t mz_stream_ioapi_write(void *stream, const void *buf, int64_t size) {
     mz_stream_ioapi *ioapi = (mz_stream_ioapi *)stream;
     write_file_func zwrite = NULL;
     int32_t written = 0;
@@ -126,7 +126,7 @@ static int64_t mz_stream_ioapi_tell(void *stream) {
     return MZ_INTERNAL_ERROR;
 }
 
-static int32_t mz_stream_ioapi_seek(void *stream, int64_t offset, int32_t origin) {
+static int64_t mz_stream_ioapi_seek(void *stream, int64_t offset, int32_t origin) {
     mz_stream_ioapi *ioapi = (mz_stream_ioapi *)stream;
 
     if (mz_stream_ioapi_is_open(stream) != MZ_OK)

--- a/mz_strm.c
+++ b/mz_strm.c
@@ -31,7 +31,7 @@ int32_t mz_stream_is_open(void *stream) {
     return strm->vtbl->is_open(strm);
 }
 
-int32_t mz_stream_read(void *stream, void *buf, int32_t size) {
+int64_t mz_stream_read(void *stream, void *buf, int64_t size) {
     mz_stream *strm = (mz_stream *)stream;
     if (!strm || !strm->vtbl || !strm->vtbl->read)
         return MZ_PARAM_ERROR;
@@ -98,7 +98,7 @@ int32_t mz_stream_read_uint64(void *stream, uint64_t *value) {
     return mz_stream_read_value(stream, value, sizeof(uint64_t));
 }
 
-int32_t mz_stream_write(void *stream, const void *buf, int32_t size) {
+int64_t mz_stream_write(void *stream, const void *buf, int64_t size) {
     mz_stream *strm = (mz_stream *)stream;
     if (size == 0)
         return size;
@@ -442,14 +442,14 @@ int32_t mz_stream_raw_is_open(void *stream) {
     return mz_stream_is_open(raw->stream.base);
 }
 
-int32_t mz_stream_raw_read(void *stream, void *buf, int32_t size) {
+int64_t mz_stream_raw_read(void *stream, void *buf, int64_t size) {
     mz_stream_raw *raw = (mz_stream_raw *)stream;
-    int32_t bytes_to_read = size;
-    int32_t read = 0;
+    int64_t bytes_to_read = size;
+    int64_t read = 0;
 
     if (raw->max_total_in > 0) {
         if ((int64_t)bytes_to_read > (raw->max_total_in - raw->total_in))
-            bytes_to_read = (int32_t)(raw->max_total_in - raw->total_in);
+            bytes_to_read = (int64_t)(raw->max_total_in - raw->total_in);
     }
 
     read = mz_stream_read(raw->stream.base, buf, bytes_to_read);
@@ -462,9 +462,9 @@ int32_t mz_stream_raw_read(void *stream, void *buf, int32_t size) {
     return read;
 }
 
-int32_t mz_stream_raw_write(void *stream, const void *buf, int32_t size) {
+int64_t mz_stream_raw_write(void *stream, const void *buf, int64_t size) {
     mz_stream_raw *raw = (mz_stream_raw *)stream;
-    int32_t written = 0;
+    int64_t written = 0;
 
     written = mz_stream_write(raw->stream.base, buf, size);
 
@@ -481,7 +481,7 @@ int64_t mz_stream_raw_tell(void *stream) {
     return mz_stream_tell(raw->stream.base);
 }
 
-int32_t mz_stream_raw_seek(void *stream, int64_t offset, int32_t origin) {
+int64_t mz_stream_raw_seek(void *stream, int64_t offset, int32_t origin) {
     mz_stream_raw *raw = (mz_stream_raw *)stream;
     return mz_stream_seek(raw->stream.base, offset, origin);
 }

--- a/mz_strm.c
+++ b/mz_strm.c
@@ -33,6 +33,10 @@ int32_t mz_stream_is_open(void *stream) {
 
 int64_t mz_stream_read(void *stream, void *buf, int64_t size) {
     mz_stream *strm = (mz_stream *)stream;
+
+    if (size < 0)
+        return MZ_PARAM_ERROR;
+
     if (!strm || !strm->vtbl || !strm->vtbl->read)
         return MZ_PARAM_ERROR;
     if (mz_stream_is_open(strm) != MZ_OK)
@@ -100,8 +104,13 @@ int32_t mz_stream_read_uint64(void *stream, uint64_t *value) {
 
 int64_t mz_stream_write(void *stream, const void *buf, int64_t size) {
     mz_stream *strm = (mz_stream *)stream;
+
+    if (size < 0)
+        return MZ_PARAM_ERROR;
+
     if (size == 0)
         return size;
+
     if (!strm || !strm->vtbl || !strm->vtbl->write)
         return MZ_PARAM_ERROR;
     if (mz_stream_is_open(strm) != MZ_OK)
@@ -447,6 +456,9 @@ int64_t mz_stream_raw_read(void *stream, void *buf, int64_t size) {
     int64_t bytes_to_read = size;
     int64_t read = 0;
 
+    if (size < 0)
+        return MZ_PARAM_ERROR;
+
     if (raw->max_total_in > 0) {
         if ((int64_t)bytes_to_read > (raw->max_total_in - raw->total_in))
             bytes_to_read = (int64_t)(raw->max_total_in - raw->total_in);
@@ -465,6 +477,9 @@ int64_t mz_stream_raw_read(void *stream, void *buf, int64_t size) {
 int64_t mz_stream_raw_write(void *stream, const void *buf, int64_t size) {
     mz_stream_raw *raw = (mz_stream_raw *)stream;
     int64_t written = 0;
+    
+    if (size < 0)
+        return MZ_PARAM_ERROR;
 
     written = mz_stream_write(raw->stream.base, buf, size);
 

--- a/mz_strm.h
+++ b/mz_strm.h
@@ -34,10 +34,10 @@ extern "C" {
 
 typedef int32_t (*mz_stream_open_cb)(void *stream, const char *path, int32_t mode);
 typedef int32_t (*mz_stream_is_open_cb)(void *stream);
-typedef int32_t (*mz_stream_read_cb)(void *stream, void *buf, int32_t size);
-typedef int32_t (*mz_stream_write_cb)(void *stream, const void *buf, int32_t size);
+typedef int64_t (*mz_stream_read_cb)(void *stream, void *buf, int64_t size);
+typedef int64_t (*mz_stream_write_cb)(void *stream, const void *buf, int64_t size);
 typedef int64_t (*mz_stream_tell_cb)(void *stream);
-typedef int32_t (*mz_stream_seek_cb)(void *stream, int64_t offset, int32_t origin);
+typedef int64_t (*mz_stream_seek_cb)(void *stream, int64_t offset, int32_t origin);
 typedef int32_t (*mz_stream_close_cb)(void *stream);
 typedef int32_t (*mz_stream_error_cb)(void *stream);
 typedef void *(*mz_stream_create_cb)(void);
@@ -76,13 +76,13 @@ typedef struct mz_stream_s {
 
 int32_t mz_stream_open(void *stream, const char *path, int32_t mode);
 int32_t mz_stream_is_open(void *stream);
-int32_t mz_stream_read(void *stream, void *buf, int32_t size);
+int64_t mz_stream_read(void *stream, void *buf, int64_t size);
 int32_t mz_stream_read_uint8(void *stream, uint8_t *value);
 int32_t mz_stream_read_uint16(void *stream, uint16_t *value);
 int32_t mz_stream_read_uint32(void *stream, uint32_t *value);
 int32_t mz_stream_read_int64(void *stream, int64_t *value);
 int32_t mz_stream_read_uint64(void *stream, uint64_t *value);
-int32_t mz_stream_write(void *stream, const void *buf, int32_t size);
+int64_t mz_stream_write(void *stream, const void *buf, int64_t size);
 int32_t mz_stream_write_uint8(void *stream, uint8_t value);
 int32_t mz_stream_write_uint16(void *stream, uint16_t value);
 int32_t mz_stream_write_uint32(void *stream, uint32_t value);
@@ -113,10 +113,10 @@ void mz_stream_delete(void **stream);
 
 int32_t mz_stream_raw_open(void *stream, const char *filename, int32_t mode);
 int32_t mz_stream_raw_is_open(void *stream);
-int32_t mz_stream_raw_read(void *stream, void *buf, int32_t size);
-int32_t mz_stream_raw_write(void *stream, const void *buf, int32_t size);
+int64_t mz_stream_raw_read(void *stream, void *buf, int64_t size);
+int64_t mz_stream_raw_write(void *stream, const void *buf, int64_t size);
 int64_t mz_stream_raw_tell(void *stream);
-int32_t mz_stream_raw_seek(void *stream, int64_t offset, int32_t origin);
+int64_t mz_stream_raw_seek(void *stream, int64_t offset, int32_t origin);
 int32_t mz_stream_raw_close(void *stream);
 int32_t mz_stream_raw_error(void *stream);
 

--- a/mz_strm_buf.c
+++ b/mz_strm_buf.c
@@ -298,9 +298,9 @@ int64_t mz_stream_buffered_seek(void *stream, int64_t offset, int32_t origin) {
     case MZ_SEEK_CUR:
 
         if (buffered->readbuf_len > 0) {
-            if ((offset >= -((int64_t)buffered->writebuf_pos)) &&
-                (offset <= ((int64_t)buffered->writebuf_len - buffered->writebuf_pos))) {           
-                buffered->readbuf_pos += (uint32_t)offset;
+            if ((offset >= -((int64_t)buffered->readbuf_pos)) &&
+                (offset <= ((int64_t)buffered->readbuf_len - buffered->writebuf_pos))) {           
+                buffered->readbuf_pos += (int32_t)offset;
                 return MZ_OK;
             }
             offset -= ((int64_t)buffered->readbuf_len - buffered->readbuf_pos);

--- a/mz_strm_buf.c
+++ b/mz_strm_buf.c
@@ -116,22 +116,27 @@ static int32_t mz_stream_buffered_flush(void *stream, int32_t *written) {
 
 int64_t mz_stream_buffered_read(void *stream, void *buf, int64_t size) {
     mz_stream_buffered *buffered = (mz_stream_buffered *)stream;
-    int32_t buf_len = 0;
+    int64_t buf_len = 0;
     int32_t bytes_to_read = 0;
     int32_t bytes_to_copy = 0;
-    int32_t bytes_left_to_read = size;
+    int64_t bytes_left_to_read = size;
     int32_t bytes_read = 0;
     int32_t bytes_flushed = 0;
+    int32_t err = MZ_OK;
 
-    mz_stream_buffered_print("Buffered - Read (size %" PRId32 " pos %" PRId64 ")\n", size, buffered->position);
+    mz_stream_buffered_print("Buffered - Read (size %" PRId64 " pos %" PRId64 ")\n", size, buffered->position);
 
     if (buffered->writebuf_len > 0) {
         int64_t position = buffered->position + buffered->writebuf_pos;
 
         mz_stream_buffered_print("Buffered - Switch from write to read, flushing (pos %" PRId64 ")\n", position);
 
-        mz_stream_buffered_flush(stream, &bytes_flushed);
-        mz_stream_buffered_seek(stream, position, MZ_SEEK_SET);
+        err = mz_stream_buffered_flush(stream, &bytes_flushed);
+        if (err != MZ_OK)
+            return err;
+        err = mz_stream_buffered_seek(stream, position, MZ_SEEK_SET);
+        if (err != MZ_OK)
+            return err;
     }
 
     while (bytes_left_to_read > 0) {
@@ -172,7 +177,7 @@ int64_t mz_stream_buffered_read(void *stream, void *buf, int64_t size) {
             buffered->readbuf_hits += 1;
             buffered->readbuf_pos += bytes_to_copy;
 
-            mz_stream_buffered_print("Buffered - Emptied (copied %" PRId32 " remaining %" PRId32 " buf %" PRId32
+            mz_stream_buffered_print("Buffered - Emptied (copied %" PRId32 " remaining %" PRId64 " buf %" PRId32
                                      ":%" PRId32 " pos %" PRId64 ")\n",
                                      bytes_to_copy, bytes_left_to_read, buffered->readbuf_pos, buffered->readbuf_len,
                                      buffered->position);
@@ -269,7 +274,7 @@ int64_t mz_stream_buffered_seek(void *stream, int64_t offset, int32_t origin) {
                              offset, buffered->position);
 
     switch (origin) {
-    case MZ_SEEK_SET:
+    case MZ_SEEK_SET: 
 
         if ((buffered->readbuf_len > 0) && (offset < buffered->position) &&
             (offset >= buffered->position - buffered->readbuf_len)) {
@@ -293,7 +298,8 @@ int64_t mz_stream_buffered_seek(void *stream, int64_t offset, int32_t origin) {
     case MZ_SEEK_CUR:
 
         if (buffered->readbuf_len > 0) {
-            if (offset <= ((int64_t)buffered->readbuf_len - buffered->readbuf_pos)) {
+            if ((offset >= -((int64_t)buffered->writebuf_pos)) &&
+                (offset <= ((int64_t)buffered->writebuf_len - buffered->writebuf_pos))) {           
                 buffered->readbuf_pos += (uint32_t)offset;
                 return MZ_OK;
             }
@@ -301,7 +307,8 @@ int64_t mz_stream_buffered_seek(void *stream, int64_t offset, int32_t origin) {
             buffered->position += offset;
         }
         if (buffered->writebuf_len > 0) {
-            if (offset <= ((int64_t)buffered->writebuf_len - buffered->writebuf_pos)) {
+            if ((offset >= -((int64_t)buffered->writebuf_pos)) &&
+                (offset <= ((int64_t)buffered->writebuf_len - buffered->writebuf_pos))) {
                 buffered->writebuf_pos += (uint32_t)offset;
                 return MZ_OK;
             }

--- a/mz_strm_buf.c
+++ b/mz_strm_buf.c
@@ -299,7 +299,7 @@ int64_t mz_stream_buffered_seek(void *stream, int64_t offset, int32_t origin) {
 
         if (buffered->readbuf_len > 0) {
             if ((offset >= -((int64_t)buffered->readbuf_pos)) &&
-                (offset <= ((int64_t)buffered->readbuf_len - buffered->writebuf_pos))) {           
+                (offset <= ((int64_t)buffered->readbuf_len - buffered->readbuf_pos))) {           
                 buffered->readbuf_pos += (int32_t)offset;
                 return MZ_OK;
             }
@@ -309,7 +309,7 @@ int64_t mz_stream_buffered_seek(void *stream, int64_t offset, int32_t origin) {
         if (buffered->writebuf_len > 0) {
             if ((offset >= -((int64_t)buffered->writebuf_pos)) &&
                 (offset <= ((int64_t)buffered->writebuf_len - buffered->writebuf_pos))) {
-                buffered->writebuf_pos += (uint32_t)offset;
+                buffered->writebuf_pos += (int32_t)offset;
                 return MZ_OK;
             }
             /* offset -= (buffered->writebuf_len - buffered->writebuf_pos); */

--- a/mz_strm_buf.c
+++ b/mz_strm_buf.c
@@ -114,7 +114,7 @@ static int32_t mz_stream_buffered_flush(void *stream, int32_t *written) {
     return MZ_OK;
 }
 
-int32_t mz_stream_buffered_read(void *stream, void *buf, int32_t size) {
+int64_t mz_stream_buffered_read(void *stream, void *buf, int64_t size) {
     mz_stream_buffered *buffered = (mz_stream_buffered *)stream;
     int32_t buf_len = 0;
     int32_t bytes_to_read = 0;
@@ -182,7 +182,7 @@ int32_t mz_stream_buffered_read(void *stream, void *buf, int32_t size) {
     return size - bytes_left_to_read;
 }
 
-int32_t mz_stream_buffered_write(void *stream, const void *buf, int32_t size) {
+int64_t mz_stream_buffered_write(void *stream, const void *buf, int64_t size) {
     mz_stream_buffered *buffered = (mz_stream_buffered *)stream;
     int32_t bytes_to_write = size;
     int32_t bytes_left_to_write = size;
@@ -260,7 +260,7 @@ int64_t mz_stream_buffered_tell(void *stream) {
     return position;
 }
 
-int32_t mz_stream_buffered_seek(void *stream, int64_t offset, int32_t origin) {
+int64_t mz_stream_buffered_seek(void *stream, int64_t offset, int32_t origin) {
     mz_stream_buffered *buffered = (mz_stream_buffered *)stream;
     int32_t bytes_flushed = 0;
     int32_t err = MZ_OK;

--- a/mz_strm_buf.h
+++ b/mz_strm_buf.h
@@ -21,10 +21,10 @@ extern "C" {
 
 int32_t mz_stream_buffered_open(void *stream, const char *path, int32_t mode);
 int32_t mz_stream_buffered_is_open(void *stream);
-int32_t mz_stream_buffered_read(void *stream, void *buf, int32_t size);
-int32_t mz_stream_buffered_write(void *stream, const void *buf, int32_t size);
+int64_t mz_stream_buffered_read(void *stream, void *buf, int64_t size);
+int64_t mz_stream_buffered_write(void *stream, const void *buf, int64_t size);
 int64_t mz_stream_buffered_tell(void *stream);
-int32_t mz_stream_buffered_seek(void *stream, int64_t offset, int32_t origin);
+int64_t mz_stream_buffered_seek(void *stream, int64_t offset, int32_t origin);
 int32_t mz_stream_buffered_close(void *stream);
 int32_t mz_stream_buffered_error(void *stream);
 

--- a/mz_strm_bzip.c
+++ b/mz_strm_bzip.c
@@ -92,7 +92,7 @@ int32_t mz_stream_bzip_is_open(void *stream) {
     return MZ_OK;
 }
 
-int32_t mz_stream_bzip_read(void *stream, void *buf, int32_t size) {
+int64_t mz_stream_bzip_read(void *stream, void *buf, int64_t size) {
 #ifdef MZ_ZIP_NO_DECOMPRESSION
     MZ_UNUSED(stream);
     MZ_UNUSED(buf);
@@ -216,7 +216,7 @@ static int32_t mz_stream_bzip_compress(void *stream, int flush) {
 }
 #endif
 
-int32_t mz_stream_bzip_write(void *stream, const void *buf, int32_t size) {
+int64_t mz_stream_bzip_write(void *stream, const void *buf, int64_t size) {
 #ifdef MZ_ZIP_NO_COMPRESSION
     MZ_UNUSED(stream);
     MZ_UNUSED(buf);
@@ -245,7 +245,7 @@ int64_t mz_stream_bzip_tell(void *stream) {
     return MZ_TELL_ERROR;
 }
 
-int32_t mz_stream_bzip_seek(void *stream, int64_t offset, int32_t origin) {
+int64_t mz_stream_bzip_seek(void *stream, int64_t offset, int32_t origin) {
     MZ_UNUSED(stream);
     MZ_UNUSED(offset);
     MZ_UNUSED(origin);

--- a/mz_strm_bzip.c
+++ b/mz_strm_bzip.c
@@ -120,7 +120,7 @@ int64_t mz_stream_bzip_read(void *stream, void *buf, int64_t size) {
 
     while (total_out < size)
     {
-        avail_out_chunk = (size > UINT_MAX) ? UINT_MAX : (unsigned int)(size - total_out);
+        avail_out_chunk = ((size - total_out) > UINT_MAX) ? UINT_MAX : (unsigned int)(size - total_out);
 
         bzip->bzstream.next_out = (char *)buf + total_out;
         bzip->bzstream.avail_out = avail_out_chunk;

--- a/mz_strm_bzip.c
+++ b/mz_strm_bzip.c
@@ -130,6 +130,8 @@ int64_t mz_stream_bzip_read(void *stream, void *buf, int64_t size) {
                 if (bzip->max_total_in > 0) {
                     if ((int64_t)bytes_to_read > (bzip->max_total_in - bzip->total_in))
                         bytes_to_read = (int32_t)(bzip->max_total_in - bzip->total_in);
+                    if (bytes_to_read <= 0)
+                        return total_out;
                 }
 
                 read = mz_stream_read(bzip->stream.base, bzip->buffer, bytes_to_read);

--- a/mz_strm_bzip.c
+++ b/mz_strm_bzip.c
@@ -104,60 +104,72 @@ int64_t mz_stream_bzip_read(void *stream, void *buf, int64_t size) {
     uint64_t total_out_before = 0;
     uint64_t total_in_after = 0;
     uint64_t total_out_after = 0;
-    int32_t total_out = 0;
+    uint64_t total_out = 0;
     int32_t in_bytes = 0;
     int32_t out_bytes = 0;
     int32_t bytes_to_read = sizeof(bzip->buffer);
     int32_t read = 0;
     int32_t err = BZ_OK;
+    unsigned int avail_out_chunk;
+
+    if (size < 0)
+        return MZ_PARAM_ERROR;
 
     if (bzip->stream_end)
         return 0;
 
-    bzip->bzstream.next_out = (char *)buf;
-    bzip->bzstream.avail_out = (unsigned int)size;
+    while (total_out < size)
+    {
+        avail_out_chunk = (size > UINT_MAX) ? UINT_MAX : (unsigned int)(size - total_out);
 
-    do {
-        if (bzip->bzstream.avail_in == 0) {
-            if (bzip->max_total_in > 0) {
-                if ((int64_t)bytes_to_read > (bzip->max_total_in - bzip->total_in))
-                    bytes_to_read = (int32_t)(bzip->max_total_in - bzip->total_in);
+        bzip->bzstream.next_out = (char *)buf + total_out;
+        bzip->bzstream.avail_out = avail_out_chunk;
+
+        do {
+            if (bzip->bzstream.avail_in == 0) {
+                if (bzip->max_total_in > 0) {
+                    if ((int64_t)bytes_to_read > (bzip->max_total_in - bzip->total_in))
+                        bytes_to_read = (int32_t)(bzip->max_total_in - bzip->total_in);
+                }
+
+                read = mz_stream_read(bzip->stream.base, bzip->buffer, bytes_to_read);
+
+                if (read < 0)
+                    return read;
+
+                if (read == 0)
+                    break;
+
+                bzip->bzstream.next_in = (char *)bzip->buffer;
+                bzip->bzstream.avail_in = (uint32_t)read;
             }
 
-            read = mz_stream_read(bzip->stream.base, bzip->buffer, bytes_to_read);
+            total_in_before = bzip->bzstream.avail_in;
+            total_out_before = bzip->bzstream.total_out_lo32 + (((uint64_t)bzip->bzstream.total_out_hi32) << 32);
 
-            if (read < 0)
-                return read;
+            err = BZ2_bzDecompress(&bzip->bzstream);
 
-            bzip->bzstream.next_in = (char *)bzip->buffer;
-            bzip->bzstream.avail_in = (uint32_t)read;
-        }
+            total_in_after = bzip->bzstream.avail_in;
+            total_out_after = bzip->bzstream.total_out_lo32 + (((uint64_t)bzip->bzstream.total_out_hi32) << 32);
 
-        total_in_before = bzip->bzstream.avail_in;
-        total_out_before = bzip->bzstream.total_out_lo32 + (((uint64_t)bzip->bzstream.total_out_hi32) << 32);
+            in_bytes = (int32_t)(total_in_before - total_in_after);
+            out_bytes = (int32_t)(total_out_after - total_out_before);
 
-        err = BZ2_bzDecompress(&bzip->bzstream);
+            total_out += out_bytes;
 
-        total_in_after = bzip->bzstream.avail_in;
-        total_out_after = bzip->bzstream.total_out_lo32 + (((uint64_t)bzip->bzstream.total_out_hi32) << 32);
+            bzip->total_in += in_bytes;
+            bzip->total_out += out_bytes;
 
-        in_bytes = (int32_t)(total_in_before - total_in_after);
-        out_bytes = (int32_t)(total_out_after - total_out_before);
-
-        total_out += out_bytes;
-
-        bzip->total_in += in_bytes;
-        bzip->total_out += out_bytes;
-
-        if (err == BZ_STREAM_END) {
-            bzip->stream_end = 1;
-            break;
-        }
-        if (err != BZ_OK && err != BZ_RUN_OK) {
-            bzip->error = err;
-            break;
-        }
-    } while (bzip->bzstream.avail_out > 0);
+            if (err == BZ_STREAM_END) {
+                bzip->stream_end = 1;
+                return total_out;
+            }
+            if (err != BZ_OK && err != BZ_RUN_OK) {
+                bzip->error = err;
+                return MZ_DATA_ERROR;
+            }
+        } while (bzip->bzstream.avail_out > 0);
+    }
 
     if (bzip->error != 0)
         return MZ_DATA_ERROR;
@@ -224,18 +236,28 @@ int64_t mz_stream_bzip_write(void *stream, const void *buf, int64_t size) {
     return MZ_SUPPORT_ERROR;
 #else
     mz_stream_bzip *bzip = (mz_stream_bzip *)stream;
+    int64_t total_written = 0;
+    unsigned int write_chunk;
     int32_t err = MZ_OK;
 
-    bzip->bzstream.next_in = (char *)(intptr_t)buf;
-    bzip->bzstream.avail_in = (unsigned int)size;
+    if (size < 0)
+        return MZ_PARAM_ERROR;
 
-    err = mz_stream_bzip_compress(stream, BZ_RUN);
-    if (err != MZ_OK) {
-        return err;
+    while (total_written < size)
+    {
+        write_chunk = (size - total_written > UINT_MAX) ? UINT_MAX : (unsigned int)(size - total_written);
+
+        bzip->bzstream.next_in = (char *)(intptr_t)buf + total_written;
+        bzip->bzstream.avail_in = write_chunk;
+
+        err = mz_stream_bzip_compress(stream, BZ_RUN);
+        if (err != MZ_OK) 
+            return err;
+
+        bzip->total_in += write_chunk;
+        total_written += write_chunk;
     }
-
-    bzip->total_in += size;
-    return size;
+    return total_written;
 #endif
 }
 

--- a/mz_strm_bzip.h
+++ b/mz_strm_bzip.h
@@ -19,10 +19,10 @@ extern "C" {
 
 int32_t mz_stream_bzip_open(void *stream, const char *filename, int32_t mode);
 int32_t mz_stream_bzip_is_open(void *stream);
-int32_t mz_stream_bzip_read(void *stream, void *buf, int32_t size);
-int32_t mz_stream_bzip_write(void *stream, const void *buf, int32_t size);
+int64_t mz_stream_bzip_read(void *stream, void *buf, int64_t size);
+int64_t mz_stream_bzip_write(void *stream, const void *buf, int64_t size);
 int64_t mz_stream_bzip_tell(void *stream);
-int32_t mz_stream_bzip_seek(void *stream, int64_t offset, int32_t origin);
+int64_t mz_stream_bzip_seek(void *stream, int64_t offset, int32_t origin);
 int32_t mz_stream_bzip_close(void *stream);
 int32_t mz_stream_bzip_error(void *stream);
 

--- a/mz_strm_lzma.c
+++ b/mz_strm_lzma.c
@@ -172,7 +172,7 @@ int64_t mz_stream_lzma_read(void *stream, void *buf, int64_t size) {
         return 0;
 
     while (total_out < size) {
-        read_chunk = (size > SIZE_MAX) ? SIZE_MAX : (size_t)(size - total_out);
+        read_chunk = ((size - total_out) > SIZE_MAX) ? SIZE_MAX : (size_t)(size - total_out);
         lzma->lstream.next_out = (uint8_t *)buf + total_out;
         lzma->lstream.avail_out = (size_t)read_chunk;
 
@@ -330,7 +330,7 @@ int64_t mz_stream_lzma_write(void *stream, const void *buf, int64_t size) {
 
     while(total_written < size)
     {
-        write_chunk = (size > SIZE_MAX) ? SIZE_MAX : (size_t)(size - total_written);
+        write_chunk = ((size - total_written) > SIZE_MAX) ? SIZE_MAX : (size_t)(size - total_written);
 
         lzma->lstream.next_in = (uint8_t *)(intptr_t)buf + total_written;
         lzma->lstream.avail_in = write_chunk;

--- a/mz_strm_lzma.c
+++ b/mz_strm_lzma.c
@@ -144,7 +144,7 @@ int32_t mz_stream_lzma_is_open(void *stream) {
     return MZ_OK;
 }
 
-int32_t mz_stream_lzma_read(void *stream, void *buf, int32_t size) {
+int64_t mz_stream_lzma_read(void *stream, void *buf, int64_t size) {
 #ifdef MZ_ZIP_NO_DECOMPRESSION
     MZ_UNUSED(stream);
     MZ_UNUSED(buf);
@@ -308,7 +308,7 @@ static int32_t mz_stream_lzma_code(void *stream, int32_t flush) {
 }
 #endif
 
-int32_t mz_stream_lzma_write(void *stream, const void *buf, int32_t size) {
+int64_t mz_stream_lzma_write(void *stream, const void *buf, int64_t size) {
 #ifdef MZ_ZIP_NO_COMPRESSION
     MZ_UNUSED(stream);
     MZ_UNUSED(buf);
@@ -337,7 +337,7 @@ int64_t mz_stream_lzma_tell(void *stream) {
     return MZ_TELL_ERROR;
 }
 
-int32_t mz_stream_lzma_seek(void *stream, int64_t offset, int32_t origin) {
+int64_t mz_stream_lzma_seek(void *stream, int64_t offset, int32_t origin) {
     MZ_UNUSED(stream);
     MZ_UNUSED(offset);
     MZ_UNUSED(origin);

--- a/mz_strm_lzma.c
+++ b/mz_strm_lzma.c
@@ -157,93 +157,97 @@ int64_t mz_stream_lzma_read(void *stream, void *buf, int64_t size) {
     uint64_t total_in_after = 0;
     uint64_t total_out_after = 0;
     int32_t total_in = 0;
-    int32_t total_out = 0;
+    int64_t total_out = 0;
     int32_t in_bytes = 0;
     int32_t out_bytes = 0;
     int32_t bytes_to_read = sizeof(lzma->buffer);
     int32_t read = 0;
     int32_t err = LZMA_OK;
+    size_t read_chunk;
+    uint8_t eof = 0;
 
-    lzma->lstream.next_out = (uint8_t *)buf;
-    lzma->lstream.avail_out = (size_t)size;
+    if (size < 0)
+        return MZ_PARAM_ERROR;
+    if (size == 0)
+        return 0;
 
-    do {
-        if (lzma->lstream.avail_in == 0) {
-            if (lzma->max_total_in > 0) {
-                if ((int64_t)bytes_to_read > (lzma->max_total_in - lzma->total_in))
-                    bytes_to_read = (int32_t)(lzma->max_total_in - lzma->total_in);
-            }
+    while (total_out < size) {
+        read_chunk = (size > SIZE_MAX) ? SIZE_MAX : (size_t)(size - total_out);
+        lzma->lstream.next_out = (uint8_t *)buf + total_out;
+        lzma->lstream.avail_out = (size_t)read_chunk;
 
-            if (lzma->header) {
-                bytes_to_read = MZ_LZMA_ZIP_HEADER_SIZE - lzma->header_size;
-            }
-
-            read = mz_stream_read(lzma->stream.base, lzma->buffer, bytes_to_read);
-
-            if (read < 0)
-                return read;
-
-            /* Write uncompressed size for lzma alone header not in zip format */
-            if (lzma->header) {
-                lzma->header_size += read;
-
-                if (lzma->header_size == MZ_LZMA_ZIP_HEADER_SIZE) {
-                    uint64_t uncompressed_size = UINT64_MAX;
-
-                    memcpy(lzma->buffer + MZ_LZMA_ZIP_HEADER_SIZE, &uncompressed_size, sizeof(uncompressed_size));
-
-                    read += sizeof(uncompressed_size);
-                    bytes_to_read = sizeof(lzma->buffer);
-
-                    lzma->total_in -= sizeof(uncompressed_size);
-                    lzma->header = 0;
+        do {
+            if (lzma->lstream.avail_in == 0) {
+                if (lzma->max_total_in > 0) {
+                    if ((int64_t)bytes_to_read > (lzma->max_total_in - lzma->total_in))
+                        bytes_to_read = (int32_t)(lzma->max_total_in - lzma->total_in);
                 }
+                if (lzma->header) {
+                    bytes_to_read = MZ_LZMA_ZIP_HEADER_SIZE - lzma->header_size;
+                }
+                read = mz_stream_read(lzma->stream.base, lzma->buffer, bytes_to_read);
+                if (read < 0)
+                    return read;
+                if (read == 0) {
+                    eof = 1;
+                    break; 
+                }
+                if (lzma->header) {
+                    lzma->header_size += read;
+                    if (lzma->header_size == MZ_LZMA_ZIP_HEADER_SIZE) {
+                        uint64_t uncompressed_size = UINT64_MAX;
+                        memcpy(lzma->buffer + MZ_LZMA_ZIP_HEADER_SIZE, &uncompressed_size, sizeof(uncompressed_size));
+                        read += sizeof(uncompressed_size);
+                        bytes_to_read = sizeof(lzma->buffer);
+                        lzma->total_in -= sizeof(uncompressed_size);
+                        lzma->header = 0;
+                    }
+                }
+                lzma->lstream.next_in = lzma->buffer;
+                lzma->lstream.avail_in = (size_t)read;
             }
 
-            lzma->lstream.next_in = lzma->buffer;
-            lzma->lstream.avail_in = (size_t)read;
-        }
+            total_in_before = lzma->lstream.avail_in;
+            total_out_before = lzma->lstream.total_out;
+            err = lzma_code(&lzma->lstream, eof ? LZMA_FINISH : LZMA_RUN);
+            total_in_after = lzma->lstream.avail_in;
+            total_out_after = lzma->lstream.total_out;
+            if ((lzma->max_total_out != -1) && (int64_t)total_out_after > lzma->max_total_out)
+                total_out_after = (uint64_t)lzma->max_total_out;
+            in_bytes = (int32_t)(total_in_before - total_in_after);
+            out_bytes = (int32_t)(total_out_after - total_out_before);
+            total_in += in_bytes;
+            total_out += out_bytes;
+            lzma->total_in += in_bytes;
+            lzma->total_out += out_bytes;
 
-        total_in_before = lzma->lstream.avail_in;
-        total_out_before = lzma->lstream.total_out;
+            if (err == LZMA_STREAM_END)
+                return total_out;
+            if (err != LZMA_OK) {
+                lzma->error = err;
+                return MZ_DATA_ERROR;
+            }
 
-        err = lzma_code(&lzma->lstream, LZMA_RUN);
+            if (eof && in_bytes == 0 && out_bytes == 0) {
+                lzma->error = LZMA_DATA_ERROR;
+                return MZ_DATA_ERROR;
+            }
+        } while (lzma->lstream.avail_out > 0 && !(eof && lzma->lstream.avail_in == 0 && in_bytes == 0 && out_bytes == 0));
 
-        total_in_after = lzma->lstream.avail_in;
-        total_out_after = lzma->lstream.total_out;
-        if ((lzma->max_total_out != -1) && (int64_t)total_out_after > lzma->max_total_out)
-            total_out_after = (uint64_t)lzma->max_total_out;
-
-        in_bytes = (int32_t)(total_in_before - total_in_after);
-        out_bytes = (int32_t)(total_out_after - total_out_before);
-
-        total_in += in_bytes;
-        total_out += out_bytes;
-
-        lzma->total_in += in_bytes;
-        lzma->total_out += out_bytes;
-
-        if (err == LZMA_STREAM_END)
-            break;
-        if (err != LZMA_OK) {
-            lzma->error = err;
-            break;
-        }
-    } while (lzma->lstream.avail_out > 0);
+        if (eof && lzma->lstream.avail_in == 0)
+            break; 
+    }
 
     MZ_UNUSED(total_in);
-
     if (lzma->error != 0)
         return MZ_DATA_ERROR;
-
     return total_out;
 #endif
 }
-
 #ifndef MZ_ZIP_NO_COMPRESSION
 static int32_t mz_stream_lzma_flush(void *stream) {
     mz_stream_lzma *lzma = (mz_stream_lzma *)stream;
-    int32_t buffer_len = lzma->buffer_len;
+        int32_t buffer_len = lzma->buffer_len;
     uint8_t *buffer = lzma->buffer;
 
     /* Skip writing lzma_alone header uncompressed size for zip format */
@@ -317,17 +321,33 @@ int64_t mz_stream_lzma_write(void *stream, const void *buf, int64_t size) {
 #else
     mz_stream_lzma *lzma = (mz_stream_lzma *)stream;
     int32_t err = MZ_OK;
+    int64_t total_written = 0;
+    size_t write_chunk;
+    size_t bytes_written;
 
-    lzma->lstream.next_in = (uint8_t *)(intptr_t)buf;
-    lzma->lstream.avail_in = (size_t)size;
+    if (size < 0)
+        return MZ_PARAM_ERROR;
 
-    err = mz_stream_lzma_code(stream, LZMA_RUN);
-    if (err != MZ_OK) {
-        return err;
+    while(total_written < size)
+    {
+        write_chunk = (size > SIZE_MAX) ? SIZE_MAX : (size_t)(size - total_written);
+
+        lzma->lstream.next_in = (uint8_t *)(intptr_t)buf + total_written;
+        lzma->lstream.avail_in = write_chunk;
+
+        err = mz_stream_lzma_code(stream, LZMA_RUN);
+        if (err != MZ_OK) {
+            return err;
+        }
+
+        bytes_written = write_chunk - lzma->lstream.avail_in;
+        lzma->total_in += bytes_written;
+        total_written += bytes_written;
+        
+        if (bytes_written == 0)
+            break;
     }
-
-    lzma->total_in += size;
-    return size;
+        return total_written;
 #endif
 }
 

--- a/mz_strm_lzma.h
+++ b/mz_strm_lzma.h
@@ -19,10 +19,10 @@ extern "C" {
 
 int32_t mz_stream_lzma_open(void *stream, const char *filename, int32_t mode);
 int32_t mz_stream_lzma_is_open(void *stream);
-int32_t mz_stream_lzma_read(void *stream, void *buf, int32_t size);
-int32_t mz_stream_lzma_write(void *stream, const void *buf, int32_t size);
+int64_t mz_stream_lzma_read(void *stream, void *buf, int64_t size);
+int64_t mz_stream_lzma_write(void *stream, const void *buf, int64_t size);
 int64_t mz_stream_lzma_tell(void *stream);
-int32_t mz_stream_lzma_seek(void *stream, int64_t offset, int32_t origin);
+int64_t mz_stream_lzma_seek(void *stream, int64_t offset, int32_t origin);
 int32_t mz_stream_lzma_close(void *stream);
 int32_t mz_stream_lzma_error(void *stream);
 

--- a/mz_strm_mem.c
+++ b/mz_strm_mem.c
@@ -41,21 +41,26 @@ typedef struct mz_stream_mem_s {
     mz_stream stream;
     int32_t mode;
     uint8_t *buffer;   /* Memory buffer pointer */
-    size_t size;      /* Size of the memory buffer */
-    size_t limit;     /* Furthest we've written */
-    size_t position;  /* Current position in the memory */
-    size_t grow_size; /* Size to grow when full */
+    int64_t size;      /* Size of the memory buffer */
+    int64_t limit;     /* Furthest we've written */
+    int64_t position;  /* Current position in the memory */
+    int64_t grow_size; /* Size to grow when full */
 } mz_stream_mem;
 
 /***************************************************************************/
 
-static int32_t mz_stream_mem_set_size(void *stream, size_t size) {
+static int32_t mz_stream_mem_set_size(void *stream, int64_t size) {
     mz_stream_mem *mem = (mz_stream_mem *)stream;
     uint8_t *new_buf = NULL;
-    size_t copy_size; 
+    int64_t copy_size; 
 
+    if (size <= 0)
+        return MZ_BUF_ERROR;
 
-    new_buf = (uint8_t *)malloc(size);
+    if (size > SIZE_MAX)
+        return MZ_BUF_ERROR;
+
+    new_buf = (uint8_t *)malloc((size_t) size);
     if (!new_buf)
         return MZ_BUF_ERROR;
 
@@ -103,20 +108,16 @@ int32_t mz_stream_mem_is_open(void *stream) {
     return MZ_OK;
 }
 
-int32_t mz_stream_mem_read(void *stream, void *buf, size_t size) {
+int32_t mz_stream_mem_read(void *stream, void *buf, int64_t size) {
     mz_stream_mem *mem = (mz_stream_mem *)stream;
-
-    if (size == 0)
-        return 0;
-
-    if (mem->size < mem->position)
-        return 0;
 
     if (size > mem->size - mem->position)
         size = mem->size - mem->position;
-
     if (mem->position + size > mem->limit)
         size = mem->limit - mem->position;
+
+    if (size <= 0)
+        return 0;
 
     memcpy(buf, mem->buffer + mem->position, size);
     mem->position += size;
@@ -124,9 +125,9 @@ int32_t mz_stream_mem_read(void *stream, void *buf, size_t size) {
     return size;
 }
 
-int32_t mz_stream_mem_write(void *stream, const void *buf, int32_t size) {
+int32_t mz_stream_mem_write(void *stream, const void *buf, int64_t size) {
     mz_stream_mem *mem = (mz_stream_mem *)stream;
-    int32_t new_size = 0;
+    size_t new_size = 0;
     int32_t err = MZ_OK;
 
     if (!size)

--- a/mz_strm_mem.c
+++ b/mz_strm_mem.c
@@ -103,16 +103,20 @@ int32_t mz_stream_mem_is_open(void *stream) {
     return MZ_OK;
 }
 
-int32_t mz_stream_mem_read(void *stream, void *buf, int32_t size) {
+int32_t mz_stream_mem_read(void *stream, void *buf, size_t size) {
     mz_stream_mem *mem = (mz_stream_mem *)stream;
+
+    if (size == 0)
+        return 0;
+
+    if (mem->size < mem->position)
+        return 0;
 
     if (size > mem->size - mem->position)
         size = mem->size - mem->position;
+
     if (mem->position + size > mem->limit)
         size = mem->limit - mem->position;
-
-    if (size <= 0)
-        return 0;
 
     memcpy(buf, mem->buffer + mem->position, size);
     mem->position += size;

--- a/mz_strm_mem.c
+++ b/mz_strm_mem.c
@@ -137,7 +137,11 @@ int64_t mz_stream_mem_write(void *stream, const void *buf, int64_t size) {
         if (mem->mode & MZ_OPEN_MODE_CREATE) {
             new_size = mem->size;
             if (size < mem->grow_size)
+            {
+                if (new_size > INT32_MAX - mem->grow_size)
+                    return MZ_BUF_ERROR;
                 new_size += mem->grow_size;
+            }
             else
                 new_size += size;
 
@@ -145,7 +149,9 @@ int64_t mz_stream_mem_write(void *stream, const void *buf, int64_t size) {
             if (err != MZ_OK)
                 return err;
         } else {
-            size = mem->size - mem->position;
+            if (new_size > INT32_MAX - size)
+                return MZ_BUF_ERROR;
+            new_size += size;
         }
     }
 
@@ -173,9 +179,17 @@ int64_t mz_stream_mem_seek(void *stream, int64_t offset, int32_t origin) {
 
     switch (origin) {
     case MZ_SEEK_CUR:
+        if (offset > 0 && mem->position > INT64_MAX - offset)
+            return MZ_SEEK_ERROR;
+        if (offset < 0 && mem->position < INT64_MIN - offset)
+            return MZ_SEEK_ERROR;
         new_pos = mem->position + offset;
         break;
     case MZ_SEEK_END:
+        if (offset > 0 && mem->limit > INT64_MAX - offset)
+            return MZ_SEEK_ERROR;
+        if (offset < 0 && mem->limit < INT64_MIN - offset)
+            return MZ_SEEK_ERROR;
         new_pos = mem->limit + offset;
         break;
     case MZ_SEEK_SET:
@@ -218,6 +232,8 @@ int32_t mz_stream_mem_error(void *stream) {
 
 void mz_stream_mem_set_buffer(void *stream, void *buf, int64_t size) {
     mz_stream_mem *mem = (mz_stream_mem *)stream;
+    if (size < 0)
+        size = 0;
     mem->buffer = (uint8_t *)buf;
     mem->size = size;
     mem->limit = size;
@@ -247,6 +263,12 @@ void mz_stream_mem_get_buffer_length(void *stream, int64_t *length) {
 
 void mz_stream_mem_set_buffer_limit(void *stream, int64_t limit) {
     mz_stream_mem *mem = (mz_stream_mem *)stream;
+
+    if (limit < 0)
+        limit = 0;
+    if (limit > mem->size)
+        limit = mem->size;
+
     mem->limit = limit;
 }
 

--- a/mz_strm_mem.c
+++ b/mz_strm_mem.c
@@ -128,30 +128,40 @@ int64_t mz_stream_mem_read(void *stream, void *buf, int64_t size) {
 int64_t mz_stream_mem_write(void *stream, const void *buf, int64_t size) {
     mz_stream_mem *mem = (mz_stream_mem *)stream;
     int64_t new_size = 0;
+    int64_t required_size;
+    int64_t grow_size;
     int32_t err = MZ_OK;
 
-    if (size <= 0)
+    if (size == 0)
         return 0;
 
-    if (size > mem->size - mem->position) {
+    if (size <= 0)
+        return MZ_PARAM_ERROR;
+
+    if (size > INT64_MAX - mem->position) 
+        return MZ_BUF_ERROR;
+
+    if (mem->position + size > mem->size)
+    {
         if (mem->mode & MZ_OPEN_MODE_CREATE) {
             new_size = mem->size;
-            if (size < mem->grow_size)
-            {
-                if (new_size > INT32_MAX - mem->grow_size)
-                    return MZ_BUF_ERROR;
-                new_size += mem->grow_size;
-            }
-            else
-                new_size += size;
+            required_size = mem->position + size;
+            grow_size = mem->grow_size;
+
+            if (grow_size <= 0 || grow_size < required_size - new_size)
+                grow_size = required_size - new_size;
+            if (new_size > INT64_MAX - grow_size)
+                return MZ_BUF_ERROR;
+
+            new_size += grow_size;
 
             err = mz_stream_mem_set_size(stream, new_size);
             if (err != MZ_OK)
                 return err;
         } else {
-            if (new_size > INT32_MAX - size)
-                return MZ_BUF_ERROR;
-            new_size += size;
+            size = mem->size - mem->position;
+            if (size <=0)
+                return 0;
         }
     }
 

--- a/mz_strm_mem.c
+++ b/mz_strm_mem.c
@@ -108,7 +108,7 @@ int32_t mz_stream_mem_is_open(void *stream) {
     return MZ_OK;
 }
 
-int32_t mz_stream_mem_read(void *stream, void *buf, int64_t size) {
+int64_t mz_stream_mem_read(void *stream, void *buf, int64_t size) {
     mz_stream_mem *mem = (mz_stream_mem *)stream;
 
     if (size > mem->size - mem->position)
@@ -125,13 +125,13 @@ int32_t mz_stream_mem_read(void *stream, void *buf, int64_t size) {
     return size;
 }
 
-int32_t mz_stream_mem_write(void *stream, const void *buf, int64_t size) {
+int64_t mz_stream_mem_write(void *stream, const void *buf, int64_t size) {
     mz_stream_mem *mem = (mz_stream_mem *)stream;
-    size_t new_size = 0;
+    int64_t new_size = 0;
     int32_t err = MZ_OK;
 
-    if (!size)
-        return size;
+    if (size <= 0)
+        return 0;
 
     if (size > mem->size - mem->position) {
         if (mem->mode & MZ_OPEN_MODE_CREATE) {
@@ -149,7 +149,10 @@ int32_t mz_stream_mem_write(void *stream, const void *buf, int64_t size) {
         }
     }
 
-    memcpy(mem->buffer + mem->position, buf, size);
+    if (size <= 0)
+        return 0;
+
+    memcpy(mem->buffer + mem->position, buf, (size_t)size);
 
     mem->position += size;
     if (mem->position > mem->limit)
@@ -163,7 +166,7 @@ int64_t mz_stream_mem_tell(void *stream) {
     return mem->position;
 }
 
-int32_t mz_stream_mem_seek(void *stream, int64_t offset, int32_t origin) {
+int64_t mz_stream_mem_seek(void *stream, int64_t offset, int32_t origin) {
     mz_stream_mem *mem = (mz_stream_mem *)stream;
     int64_t new_pos = 0;
     int32_t err = MZ_OK;
@@ -182,8 +185,7 @@ int32_t mz_stream_mem_seek(void *stream, int64_t offset, int32_t origin) {
         return MZ_SEEK_ERROR;
     }
 
-    // While `malloc` accepts a size_t, mz_stream_mem_s.size only supports an int32_t
-    if (new_pos < 0 || new_pos > INT32_MAX) {
+    if (new_pos < 0) {
         return MZ_SEEK_ERROR;
     }
 
@@ -191,12 +193,12 @@ int32_t mz_stream_mem_seek(void *stream, int64_t offset, int32_t origin) {
         if ((mem->mode & MZ_OPEN_MODE_CREATE) == 0)
             return MZ_SEEK_ERROR;
 
-        err = mz_stream_mem_set_size(stream, (int32_t)new_pos);
+        err = mz_stream_mem_set_size(stream, new_pos);
         if (err != MZ_OK)
             return err;
     }
 
-    mem->position = (int32_t)new_pos;
+    mem->position = new_pos;
     return MZ_OK;
 }
 
@@ -214,7 +216,7 @@ int32_t mz_stream_mem_error(void *stream) {
     return MZ_OK;
 }
 
-void mz_stream_mem_set_buffer(void *stream, void *buf, int32_t size) {
+void mz_stream_mem_set_buffer(void *stream, void *buf, int64_t size) {
     mz_stream_mem *mem = (mz_stream_mem *)stream;
     mem->buffer = (uint8_t *)buf;
     mem->size = size;
@@ -238,12 +240,12 @@ int32_t mz_stream_mem_get_buffer_at_current(void *stream, const void **buf) {
     return mz_stream_mem_get_buffer_at(stream, mem->position, buf);
 }
 
-void mz_stream_mem_get_buffer_length(void *stream, int32_t *length) {
+void mz_stream_mem_get_buffer_length(void *stream, int64_t *length) {
     mz_stream_mem *mem = (mz_stream_mem *)stream;
     *length = mem->limit;
 }
 
-void mz_stream_mem_set_buffer_limit(void *stream, int32_t limit) {
+void mz_stream_mem_set_buffer_limit(void *stream, int64_t limit) {
     mz_stream_mem *mem = (mz_stream_mem *)stream;
     mem->limit = limit;
 }

--- a/mz_strm_mem.c
+++ b/mz_strm_mem.c
@@ -41,30 +41,40 @@ typedef struct mz_stream_mem_s {
     mz_stream stream;
     int32_t mode;
     uint8_t *buffer;   /* Memory buffer pointer */
-    int32_t size;      /* Size of the memory buffer */
-    int32_t limit;     /* Furthest we've written */
-    int32_t position;  /* Current position in the memory */
-    int32_t grow_size; /* Size to grow when full */
+    size_t size;      /* Size of the memory buffer */
+    size_t limit;     /* Furthest we've written */
+    size_t position;  /* Current position in the memory */
+    size_t grow_size; /* Size to grow when full */
 } mz_stream_mem;
 
 /***************************************************************************/
 
-static int32_t mz_stream_mem_set_size(void *stream, int32_t size) {
+static int32_t mz_stream_mem_set_size(void *stream, size_t size) {
     mz_stream_mem *mem = (mz_stream_mem *)stream;
-    int32_t new_size = size;
     uint8_t *new_buf = NULL;
+    size_t copy_size; 
 
-    new_buf = (uint8_t *)malloc((uint32_t)new_size);
+
+    new_buf = (uint8_t *)malloc(size);
     if (!new_buf)
         return MZ_BUF_ERROR;
 
     if (mem->buffer) {
-        memcpy(new_buf, mem->buffer, mem->size);
+        if (size < mem->limit)
+            copy_size = size;
+        else
+            copy_size = mem->limit;
+
+        memcpy(new_buf, mem->buffer, copy_size);
         free(mem->buffer);
     }
 
     mem->buffer = new_buf;
-    mem->size = new_size;
+    mem->size = size;
+
+    if (mem->limit > size)
+        mem->limit = size;
+
     return MZ_OK;
 }
 

--- a/mz_strm_mem.h
+++ b/mz_strm_mem.h
@@ -19,19 +19,19 @@ extern "C" {
 
 int32_t mz_stream_mem_open(void *stream, const char *filename, int32_t mode);
 int32_t mz_stream_mem_is_open(void *stream);
-int32_t mz_stream_mem_read(void *stream, void *buf, int32_t size);
-int32_t mz_stream_mem_write(void *stream, const void *buf, int32_t size);
+int64_t mz_stream_mem_read(void *stream, void *buf, int64_t size);
+int64_t mz_stream_mem_write(void *stream, const void *buf, int64_t size);
 int64_t mz_stream_mem_tell(void *stream);
-int32_t mz_stream_mem_seek(void *stream, int64_t offset, int32_t origin);
+int64_t mz_stream_mem_seek(void *stream, int64_t offset, int32_t origin);
 int32_t mz_stream_mem_close(void *stream);
 int32_t mz_stream_mem_error(void *stream);
 
-void mz_stream_mem_set_buffer(void *stream, void *buf, int32_t size);
+void mz_stream_mem_set_buffer(void *stream, void *buf, int64_t size);
 int32_t mz_stream_mem_get_buffer(void *stream, const void **buf);
 int32_t mz_stream_mem_get_buffer_at(void *stream, int64_t position, const void **buf);
 int32_t mz_stream_mem_get_buffer_at_current(void *stream, const void **buf);
-void mz_stream_mem_get_buffer_length(void *stream, int32_t *length);
-void mz_stream_mem_set_buffer_limit(void *stream, int32_t limit);
+void mz_stream_mem_get_buffer_length(void *stream, int64_t *length);
+void mz_stream_mem_set_buffer_limit(void *stream, int64_t limit);
 void mz_stream_mem_set_grow_size(void *stream, int32_t grow_size);
 
 void *mz_stream_mem_create(void);

--- a/mz_strm_os.h
+++ b/mz_strm_os.h
@@ -19,10 +19,10 @@ extern "C" {
 
 int32_t mz_stream_os_open(void *stream, const char *path, int32_t mode);
 int32_t mz_stream_os_is_open(void *stream);
-int32_t mz_stream_os_read(void *stream, void *buf, int32_t size);
-int32_t mz_stream_os_write(void *stream, const void *buf, int32_t size);
+int64_t mz_stream_os_read(void *stream, void *buf, int64_t size);
+int64_t mz_stream_os_write(void *stream, const void *buf, int64_t size);
 int64_t mz_stream_os_tell(void *stream);
-int32_t mz_stream_os_seek(void *stream, int64_t offset, int32_t origin);
+int64_t mz_stream_os_seek(void *stream, int64_t offset, int32_t origin);
 int32_t mz_stream_os_close(void *stream);
 int32_t mz_stream_os_error(void *stream);
 

--- a/mz_strm_os_posix.c
+++ b/mz_strm_os_posix.c
@@ -118,7 +118,14 @@ int32_t mz_stream_os_is_open(void *stream) {
 
 int64_t mz_stream_os_read(void *stream, void *buf, int64_t size) {
     mz_stream_posix *posix = (mz_stream_posix *)stream;
-    int32_t read = (int32_t)fread(buf, 1, (size_t)size, posix->handle);
+
+    if (size < 0)
+        return MZ_PARAM_ERROR;
+
+    if (size == 0)
+        return 0;
+
+    int64_t read = fread(buf, 1, (size_t)size, posix->handle);
     if (read < size && ferror(posix->handle)) {
         posix->error = errno;
         return MZ_READ_ERROR;
@@ -128,7 +135,14 @@ int64_t mz_stream_os_read(void *stream, void *buf, int64_t size) {
 
 int64_t mz_stream_os_write(void *stream, const void *buf, int64_t size) {
     mz_stream_posix *posix = (mz_stream_posix *)stream;
-    int32_t written = (int32_t)fwrite(buf, 1, (size_t)size, posix->handle);
+
+    if (size < 0)
+        return MZ_PARAM_ERROR;
+
+    if (size == 0)
+        return 0;
+
+    int64_t written = fwrite(buf, 1, (size_t)size, posix->handle);
     if (written < size && ferror(posix->handle)) {
         posix->error = errno;
         return MZ_WRITE_ERROR;

--- a/mz_strm_os_posix.c
+++ b/mz_strm_os_posix.c
@@ -116,7 +116,7 @@ int32_t mz_stream_os_is_open(void *stream) {
     return MZ_OK;
 }
 
-int32_t mz_stream_os_read(void *stream, void *buf, int32_t size) {
+int64_t mz_stream_os_read(void *stream, void *buf, int64_t size) {
     mz_stream_posix *posix = (mz_stream_posix *)stream;
     int32_t read = (int32_t)fread(buf, 1, (size_t)size, posix->handle);
     if (read < size && ferror(posix->handle)) {
@@ -126,7 +126,7 @@ int32_t mz_stream_os_read(void *stream, void *buf, int32_t size) {
     return read;
 }
 
-int32_t mz_stream_os_write(void *stream, const void *buf, int32_t size) {
+int64_t mz_stream_os_write(void *stream, const void *buf, int64_t size) {
     mz_stream_posix *posix = (mz_stream_posix *)stream;
     int32_t written = (int32_t)fwrite(buf, 1, (size_t)size, posix->handle);
     if (written < size && ferror(posix->handle)) {
@@ -146,7 +146,7 @@ int64_t mz_stream_os_tell(void *stream) {
     return position;
 }
 
-int32_t mz_stream_os_seek(void *stream, int64_t offset, int32_t origin) {
+int64_t mz_stream_os_seek(void *stream, int64_t offset, int32_t origin) {
     mz_stream_posix *posix = (mz_stream_posix *)stream;
     int32_t fseek_origin = 0;
 

--- a/mz_strm_os_win32.c
+++ b/mz_strm_os_win32.c
@@ -126,7 +126,7 @@ int32_t mz_stream_os_is_open(void *stream) {
     return MZ_OK;
 }
 
-int32_t mz_stream_os_read(void *stream, void *buf, int32_t size) {
+int64_t mz_stream_os_read(void *stream, void *buf, int64_t size) {
     mz_stream_win32 *win32 = (mz_stream_win32 *)stream;
     uint32_t read = 0;
 
@@ -144,7 +144,7 @@ int32_t mz_stream_os_read(void *stream, void *buf, int32_t size) {
     return read;
 }
 
-int32_t mz_stream_os_write(void *stream, const void *buf, int32_t size) {
+int64_t mz_stream_os_write(void *stream, const void *buf, int64_t size) {
     mz_stream_win32 *win32 = (mz_stream_win32 *)stream;
     int32_t written = 0;
 
@@ -207,7 +207,7 @@ int64_t mz_stream_os_tell(void *stream) {
     return large_pos.QuadPart;
 }
 
-int32_t mz_stream_os_seek(void *stream, int64_t offset, int32_t origin) {
+int64_t mz_stream_os_seek(void *stream, int64_t offset, int32_t origin) {
     mz_stream_win32 *win32 = (mz_stream_win32 *)stream;
     uint32_t move_method = 0xFFFFFFFF;
     int32_t err = MZ_OK;

--- a/mz_strm_os_win32.c
+++ b/mz_strm_os_win32.c
@@ -128,42 +128,93 @@ int32_t mz_stream_os_is_open(void *stream) {
 
 int64_t mz_stream_os_read(void *stream, void *buf, int64_t size) {
     mz_stream_win32 *win32 = (mz_stream_win32 *)stream;
-    uint32_t read = 0;
+    int64_t total_read = 0;
+    DWORD read_chunk;
+    DWORD bytes_read;
+    uint8_t *buf_ptr = (uint8_t *)buf;
+    
+    if (size == 0)
+        return 0;
+
+    if (size < 0)
+        return MZ_PARAM_ERROR;
 
     if (mz_stream_os_is_open(stream) != MZ_OK)
         return MZ_OPEN_ERROR;
 
-    if (!ReadFile(win32->handle, buf, size, (DWORD *)&read, NULL)) {
-        win32->error = GetLastError();
-        if (win32->error == ERROR_HANDLE_EOF)
-            win32->error = 0;
+    while(total_read < size)
+    {
+        read_chunk = (size > UINT32_MAX) ? UINT32_MAX : (size - total_read);
+
+
+        if (!ReadFile(win32->handle, buf_ptr + total_read, read_chunk, &bytes_read, NULL)) {
+            win32->error = GetLastError();
+            if (win32->error == ERROR_HANDLE_EOF)
+            {
+                win32->error = 0;
+                break;
+            }
+            return win32->error;
+        }
+
+        total_read += read_chunk;
+
+        if (bytes_read == 0)
+            break;
+        if (bytes_read < read_chunk)
+            break;
     }
+    mz_stream_os_print("Win32 - Read - %" PRId64 "\n", total_read);
 
-    mz_stream_os_print("Win32 - Read - %" PRId32 "\n", read);
-
-    return read;
+    return total_read;
 }
 
 int64_t mz_stream_os_write(void *stream, const void *buf, int64_t size) {
     mz_stream_win32 *win32 = (mz_stream_win32 *)stream;
-    int32_t written = 0;
+    int64_t total_written = 0;
+    const uint8_t *buf_ptr = (const uint8_t *)buf;
+    DWORD write_chunk = 0;
+    DWORD bytes_written = 0;
 
-    if (mz_stream_os_is_open(stream) != MZ_OK)
-        return MZ_OPEN_ERROR;
+    if (size == 0)
+        return 0;
 
-    if (!WriteFile(win32->handle, buf, size, (DWORD *)&written, NULL)) {
-        win32->error = GetLastError();
-        if (win32->error == ERROR_HANDLE_EOF)
-            win32->error = 0;
+    if (size < 0)
+        return MZ_PARAM_ERROR;
+
+    while(total_written < size)
+    {
+        write_chunk = (size > UINT32_MAX) ? UINT32_MAX : (size - total_written);
+
+        if (mz_stream_os_is_open(stream) != MZ_OK)
+            return MZ_OPEN_ERROR;
+
+        if (!WriteFile(win32->handle, buf_ptr + total_written, write_chunk, &bytes_written, NULL)) {
+            win32->error = GetLastError();
+            if (win32->error == ERROR_HANDLE_EOF)
+            {
+                win32->error = 0;
+                break;
+            }
+
+            return win32->error;
+        }
+
+        total_written += read_chunk;
+
+        if (bytes_written == 0)
+            break;
+        if (bytes_written < write_chunk)
+            break;
+
     }
-
     mz_stream_os_print("Win32 - Write - %" PRId32 "\n", written);
 
     return written;
 }
 
 static int32_t mz_stream_os_seekinternal(HANDLE handle, LARGE_INTEGER large_pos, LARGE_INTEGER *new_pos,
-                                         uint32_t move_method) {
+        uint32_t move_method) {
 #if _WIN32_WINNT >= _WIN32_WINNT_WINXP
     BOOL success = FALSE;
     success = SetFilePointerEx(handle, large_pos, new_pos, move_method);

--- a/mz_strm_os_win32.c
+++ b/mz_strm_os_win32.c
@@ -200,7 +200,7 @@ int64_t mz_stream_os_write(void *stream, const void *buf, int64_t size) {
             return win32->error;
         }
 
-        total_written += read_chunk;
+        total_written += write_chunk;
 
         if (bytes_written == 0)
             break;
@@ -208,9 +208,9 @@ int64_t mz_stream_os_write(void *stream, const void *buf, int64_t size) {
             break;
 
     }
-    mz_stream_os_print("Win32 - Write - %" PRId32 "\n", written);
+    mz_stream_os_print("Win32 - Write - %" PRId64 "\n", written);
 
-    return written;
+    return total_written;
 }
 
 static int32_t mz_stream_os_seekinternal(HANDLE handle, LARGE_INTEGER large_pos, LARGE_INTEGER *new_pos,

--- a/mz_strm_os_win32.c
+++ b/mz_strm_os_win32.c
@@ -154,7 +154,7 @@ int64_t mz_stream_os_read(void *stream, void *buf, int64_t size) {
                 win32->error = 0;
                 break;
             }
-            return win32->error;
+            return MZ_READ_ERROR;
         }
 
         total_read += read_chunk;

--- a/mz_strm_pkcrypt.c
+++ b/mz_strm_pkcrypt.c
@@ -177,12 +177,12 @@ int32_t mz_stream_pkcrypt_is_open(void *stream) {
 int64_t mz_stream_pkcrypt_read(void *stream, void *buf, int64_t size) {
     mz_stream_pkcrypt *pkcrypt = (mz_stream_pkcrypt *)stream;
     uint8_t *buf_ptr = (uint8_t *)buf;
-    int32_t bytes_to_read = size;
-    int32_t read = 0;
+    int64_t bytes_to_read = size;
+    int64_t read = 0;
     int32_t i = 0;
 
     if ((int64_t)bytes_to_read > (pkcrypt->max_total_in - pkcrypt->total_in))
-        bytes_to_read = (int32_t)(pkcrypt->max_total_in - pkcrypt->total_in);
+        bytes_to_read = pkcrypt->max_total_in - pkcrypt->total_in;
 
     read = mz_stream_read(pkcrypt->stream.base, buf, bytes_to_read);
 
@@ -198,9 +198,9 @@ int64_t mz_stream_pkcrypt_read(void *stream, void *buf, int64_t size) {
 int64_t mz_stream_pkcrypt_write(void *stream, const void *buf, int64_t size) {
     mz_stream_pkcrypt *pkcrypt = (mz_stream_pkcrypt *)stream;
     const uint8_t *buf_ptr = (const uint8_t *)buf;
-    int32_t bytes_to_write = sizeof(pkcrypt->buffer);
-    int32_t total_written = 0;
-    int32_t written = 0;
+    int64_t bytes_to_write = sizeof(pkcrypt->buffer);
+    int64_t total_written = 0;
+    int64_t written = 0;
     int32_t i = 0;
     uint16_t t = 0;
 
@@ -219,6 +219,10 @@ int64_t mz_stream_pkcrypt_write(void *stream, const void *buf, int64_t size) {
         written = mz_stream_write(pkcrypt->stream.base, pkcrypt->buffer, bytes_to_write);
         if (written < 0)
             return written;
+
+        //Deny pertial writes; Write must success fully, or fail
+        if (written != bytes_to_write)
+            return MZ_WRITE_ERROR;
 
         total_written += written;
     } while (total_written < size && written > 0);

--- a/mz_strm_pkcrypt.c
+++ b/mz_strm_pkcrypt.c
@@ -179,7 +179,7 @@ int64_t mz_stream_pkcrypt_read(void *stream, void *buf, int64_t size) {
     uint8_t *buf_ptr = (uint8_t *)buf;
     int64_t bytes_to_read = size;
     int64_t read = 0;
-    int32_t i = 0;
+    int64_t i = 0;
 
     if ((int64_t)bytes_to_read > (pkcrypt->max_total_in - pkcrypt->total_in))
         bytes_to_read = pkcrypt->max_total_in - pkcrypt->total_in;

--- a/mz_strm_pkcrypt.c
+++ b/mz_strm_pkcrypt.c
@@ -174,7 +174,7 @@ int32_t mz_stream_pkcrypt_is_open(void *stream) {
     return MZ_OK;
 }
 
-int32_t mz_stream_pkcrypt_read(void *stream, void *buf, int32_t size) {
+int64_t mz_stream_pkcrypt_read(void *stream, void *buf, int64_t size) {
     mz_stream_pkcrypt *pkcrypt = (mz_stream_pkcrypt *)stream;
     uint8_t *buf_ptr = (uint8_t *)buf;
     int32_t bytes_to_read = size;
@@ -195,7 +195,7 @@ int32_t mz_stream_pkcrypt_read(void *stream, void *buf, int32_t size) {
     return read;
 }
 
-int32_t mz_stream_pkcrypt_write(void *stream, const void *buf, int32_t size) {
+int64_t mz_stream_pkcrypt_write(void *stream, const void *buf, int64_t size) {
     mz_stream_pkcrypt *pkcrypt = (mz_stream_pkcrypt *)stream;
     const uint8_t *buf_ptr = (const uint8_t *)buf;
     int32_t bytes_to_write = sizeof(pkcrypt->buffer);
@@ -232,7 +232,7 @@ int64_t mz_stream_pkcrypt_tell(void *stream) {
     return mz_stream_tell(pkcrypt->stream.base);
 }
 
-int32_t mz_stream_pkcrypt_seek(void *stream, int64_t offset, int32_t origin) {
+int64_t mz_stream_pkcrypt_seek(void *stream, int64_t offset, int32_t origin) {
     mz_stream_pkcrypt *pkcrypt = (mz_stream_pkcrypt *)stream;
     return mz_stream_seek(pkcrypt->stream.base, offset, origin);
 }

--- a/mz_strm_pkcrypt.h
+++ b/mz_strm_pkcrypt.h
@@ -19,10 +19,10 @@ extern "C" {
 
 int32_t mz_stream_pkcrypt_open(void *stream, const char *filename, int32_t mode);
 int32_t mz_stream_pkcrypt_is_open(void *stream);
-int32_t mz_stream_pkcrypt_read(void *stream, void *buf, int32_t size);
-int32_t mz_stream_pkcrypt_write(void *stream, const void *buf, int32_t size);
+int64_t mz_stream_pkcrypt_read(void *stream, void *buf, int64_t size);
+int64_t mz_stream_pkcrypt_write(void *stream, const void *buf, int64_t size);
 int64_t mz_stream_pkcrypt_tell(void *stream);
-int32_t mz_stream_pkcrypt_seek(void *stream, int64_t offset, int32_t origin);
+int64_t mz_stream_pkcrypt_seek(void *stream, int64_t offset, int32_t origin);
 int32_t mz_stream_pkcrypt_close(void *stream);
 int32_t mz_stream_pkcrypt_error(void *stream);
 

--- a/mz_strm_ppmd.c
+++ b/mz_strm_ppmd.c
@@ -304,7 +304,7 @@ int32_t mz_stream_ppmd_is_open(void *stream) {
     return MZ_OK;
 }
 
-int32_t mz_stream_ppmd_read(void *stream, void *buf, int32_t size) {
+int64_t mz_stream_ppmd_read(void *stream, void *buf, int64_t size) {
 #ifdef MZ_ZIP_NO_DECOMPRESSION
     MZ_UNUSED(stream);
     MZ_UNUSED(buf);
@@ -356,7 +356,7 @@ int32_t mz_stream_ppmd_read(void *stream, void *buf, int32_t size) {
 #endif
 }
 
-int32_t mz_stream_ppmd_write(void *stream, const void *buf, int32_t size) {
+int64_t mz_stream_ppmd_write(void *stream, const void *buf, int64_t size) {
 #ifdef MZ_ZIP_NO_COMPRESSION
     MZ_UNUSED(stream);
     MZ_UNUSED(buf);
@@ -390,7 +390,7 @@ int64_t mz_stream_ppmd_tell(void *stream) {
     return ppmd->total_in;
 }
 
-int32_t mz_stream_ppmd_seek(void *stream, int64_t offset, int32_t origin) {
+int64_t mz_stream_ppmd_seek(void *stream, int64_t offset, int32_t origin) {
     MZ_UNUSED(stream);
     MZ_UNUSED(offset);
     MZ_UNUSED(origin);

--- a/mz_strm_ppmd.c
+++ b/mz_strm_ppmd.c
@@ -313,11 +313,17 @@ int64_t mz_stream_ppmd_read(void *stream, void *buf, int64_t size) {
 #else
     mz_stream_ppmd *ppmd = (mz_stream_ppmd *)stream;
     uint8_t *next_out = buf;
-    int32_t avail_out;
+    int64_t avail_out;
     int64_t start_in = ppmd->total_in;
     int64_t avail_in = (ppmd->max_total_in > 0 ? ppmd->max_total_in : INT64_MAX) - start_in;
     int sym = 0;
-    int32_t written = 0;
+    int64_t written = 0;
+
+    if (size < 0)
+        return MZ_PARAM_ERROR;
+
+    if (size == 0)
+        return 0;
 
     if (ppmd->end_stream)
         return MZ_OK;
@@ -365,7 +371,7 @@ int64_t mz_stream_ppmd_write(void *stream, const void *buf, int64_t size) {
 #else
     mz_stream_ppmd *ppmd = (mz_stream_ppmd *)stream;
     const uint8_t *buf_ptr = (const uint8_t *)buf;
-    int32_t bytes_written = 0;
+    int64_t bytes_written = 0;
 
     mz_setup_buffered_writer(ppmd);
     for (bytes_written = 0; bytes_written < size; bytes_written++) {

--- a/mz_strm_ppmd.h
+++ b/mz_strm_ppmd.h
@@ -19,10 +19,10 @@ extern "C" {
 
 int32_t mz_stream_ppmd_open(void *stream, const char *filename, int32_t mode);
 int32_t mz_stream_ppmd_is_open(void *stream);
-int32_t mz_stream_ppmd_read(void *stream, void *buf, int32_t size);
-int32_t mz_stream_ppmd_write(void *stream, const void *buf, int32_t size);
+int64_t mz_stream_ppmd_read(void *stream, void *buf, int64_t size);
+int64_t mz_stream_ppmd_write(void *stream, const void *buf, int64_t size);
 int64_t mz_stream_ppmd_tell(void *stream);
-int32_t mz_stream_ppmd_seek(void *stream, int64_t offset, int32_t origin);
+int64_t mz_stream_ppmd_seek(void *stream, int64_t offset, int32_t origin);
 int32_t mz_stream_ppmd_close(void *stream);
 int32_t mz_stream_ppmd_error(void *stream);
 

--- a/mz_strm_split.c
+++ b/mz_strm_split.c
@@ -213,8 +213,8 @@ int32_t mz_stream_split_is_open(void *stream) {
 
 int64_t mz_stream_split_read(void *stream, void *buf, int64_t size) {
     mz_stream_split *split = (mz_stream_split *)stream;
-    int32_t bytes_left = size;
-    int32_t read = 0;
+    int64_t bytes_left = size;
+    int64_t read = 0;
     int32_t err = MZ_OK;
     uint8_t *buf_ptr = (uint8_t *)buf;
 
@@ -252,9 +252,9 @@ int64_t mz_stream_split_read(void *stream, void *buf, int64_t size) {
 int64_t mz_stream_split_write(void *stream, const void *buf, int64_t size) {
     mz_stream_split *split = (mz_stream_split *)stream;
     int64_t position = 0;
-    int32_t written = 0;
-    int32_t bytes_left = size;
-    int32_t bytes_to_write = 0;
+    int64_t written = 0;
+    int64_t bytes_left = size;
+    int64_t bytes_to_write = 0;
     int64_t bytes_avail = 0;
     int32_t number_disk = -1;
     int32_t err = MZ_OK;
@@ -281,7 +281,7 @@ int64_t mz_stream_split_write(void *stream, const void *buf, int64_t size) {
             if (split->number_disk != -1) {
                 bytes_avail = split->disk_size - split->total_out_disk;
                 if (bytes_to_write > bytes_avail)
-                    bytes_to_write = (int32_t)bytes_avail;
+                    bytes_to_write = bytes_avail;
             }
         }
 

--- a/mz_strm_split.c
+++ b/mz_strm_split.c
@@ -211,7 +211,7 @@ int32_t mz_stream_split_is_open(void *stream) {
     return MZ_OK;
 }
 
-int32_t mz_stream_split_read(void *stream, void *buf, int32_t size) {
+int64_t mz_stream_split_read(void *stream, void *buf, int64_t size) {
     mz_stream_split *split = (mz_stream_split *)stream;
     int32_t bytes_left = size;
     int32_t read = 0;
@@ -249,7 +249,7 @@ int32_t mz_stream_split_read(void *stream, void *buf, int32_t size) {
     return size - bytes_left;
 }
 
-int32_t mz_stream_split_write(void *stream, const void *buf, int32_t size) {
+int64_t mz_stream_split_write(void *stream, const void *buf, int64_t size) {
     mz_stream_split *split = (mz_stream_split *)stream;
     int64_t position = 0;
     int32_t written = 0;
@@ -314,7 +314,7 @@ int64_t mz_stream_split_tell(void *stream) {
     return mz_stream_tell(split->stream.base);
 }
 
-int32_t mz_stream_split_seek(void *stream, int64_t offset, int32_t origin) {
+int64_t mz_stream_split_seek(void *stream, int64_t offset, int32_t origin) {
     mz_stream_split *split = (mz_stream_split *)stream;
     int64_t disk_left = 0;
     int64_t position = 0;

--- a/mz_strm_split.h
+++ b/mz_strm_split.h
@@ -19,10 +19,10 @@ extern "C" {
 
 int32_t mz_stream_split_open(void *stream, const char *filename, int32_t mode);
 int32_t mz_stream_split_is_open(void *stream);
-int32_t mz_stream_split_read(void *stream, void *buf, int32_t size);
-int32_t mz_stream_split_write(void *stream, const void *buf, int32_t size);
+int64_t mz_stream_split_read(void *stream, void *buf, int64_t size);
+int64_t mz_stream_split_write(void *stream, const void *buf, int64_t size);
 int64_t mz_stream_split_tell(void *stream);
-int32_t mz_stream_split_seek(void *stream, int64_t offset, int32_t origin);
+int64_t mz_stream_split_seek(void *stream, int64_t offset, int32_t origin);
 int32_t mz_stream_split_close(void *stream);
 int32_t mz_stream_split_error(void *stream);
 

--- a/mz_strm_wzaes.c
+++ b/mz_strm_wzaes.c
@@ -175,7 +175,7 @@ static int32_t mz_stream_wzaes_ctr_encrypt(void *stream, uint8_t *buf, int32_t s
     return err;
 }
 
-int32_t mz_stream_wzaes_read(void *stream, void *buf, int32_t size) {
+int64_t mz_stream_wzaes_read(void *stream, void *buf, int64_t size) {
     mz_stream_wzaes *wzaes = (mz_stream_wzaes *)stream;
     int64_t max_total_in = 0;
     int32_t bytes_to_read = size;
@@ -197,7 +197,7 @@ int32_t mz_stream_wzaes_read(void *stream, void *buf, int32_t size) {
     return read;
 }
 
-int32_t mz_stream_wzaes_write(void *stream, const void *buf, int32_t size) {
+int64_t mz_stream_wzaes_write(void *stream, const void *buf, int64_t size) {
     mz_stream_wzaes *wzaes = (mz_stream_wzaes *)stream;
     const uint8_t *buf_ptr = (const uint8_t *)buf;
     int32_t bytes_to_write = sizeof(wzaes->buffer);
@@ -233,7 +233,7 @@ int64_t mz_stream_wzaes_tell(void *stream) {
     return mz_stream_tell(wzaes->stream.base);
 }
 
-int32_t mz_stream_wzaes_seek(void *stream, int64_t offset, int32_t origin) {
+int64_t mz_stream_wzaes_seek(void *stream, int64_t offset, int32_t origin) {
     mz_stream_wzaes *wzaes = (mz_stream_wzaes *)stream;
     return mz_stream_seek(wzaes->stream.base, offset, origin);
 }

--- a/mz_strm_wzaes.c
+++ b/mz_strm_wzaes.c
@@ -178,12 +178,12 @@ static int32_t mz_stream_wzaes_ctr_encrypt(void *stream, uint8_t *buf, int32_t s
 int64_t mz_stream_wzaes_read(void *stream, void *buf, int64_t size) {
     mz_stream_wzaes *wzaes = (mz_stream_wzaes *)stream;
     int64_t max_total_in = 0;
-    int32_t bytes_to_read = size;
-    int32_t read = 0;
+    int64_t bytes_to_read = size;
+    int64_t read = 0;
 
     max_total_in = wzaes->max_total_in - MZ_AES_FOOTER_SIZE;
-    if ((int64_t)bytes_to_read > (max_total_in - wzaes->total_in))
-        bytes_to_read = (int32_t)(max_total_in - wzaes->total_in);
+    if (bytes_to_read > max_total_in - wzaes->total_in)
+        bytes_to_read = max_total_in - wzaes->total_in;
 
     read = mz_stream_read(wzaes->stream.base, buf, bytes_to_read);
 
@@ -200,9 +200,9 @@ int64_t mz_stream_wzaes_read(void *stream, void *buf, int64_t size) {
 int64_t mz_stream_wzaes_write(void *stream, const void *buf, int64_t size) {
     mz_stream_wzaes *wzaes = (mz_stream_wzaes *)stream;
     const uint8_t *buf_ptr = (const uint8_t *)buf;
-    int32_t bytes_to_write = sizeof(wzaes->buffer);
-    int32_t total_written = 0;
-    int32_t written = 0;
+    int64_t bytes_to_write = sizeof(wzaes->buffer);
+    int64_t total_written = 0;
+    int64_t written = 0;
 
     if (size < 0)
         return MZ_PARAM_ERROR;
@@ -220,6 +220,10 @@ int64_t mz_stream_wzaes_write(void *stream, const void *buf, int64_t size) {
         written = mz_stream_write(wzaes->stream.base, wzaes->buffer, bytes_to_write);
         if (written < 0)
             return written;
+
+        //Deny pertial writes; Write must success fully, or fail
+        if (written != bytes_to_write)  
+            return MZ_WRITE_ERROR;
 
         total_written += written;
     } while (total_written < size && written > 0);

--- a/mz_strm_wzaes.c
+++ b/mz_strm_wzaes.c
@@ -153,7 +153,7 @@ static int64_t mz_stream_wzaes_ctr_encrypt(void *stream, uint8_t *buf, int64_t s
     int64_t pos = wzaes->crypt_pos;
     int64_t i = 0;
 
-    while (i < (uint32_t)size) {
+    while (i < size) {
         if (pos == MZ_AES_BLOCK_SIZE) {
             uint32_t j = 0;
 

--- a/mz_strm_wzaes.c
+++ b/mz_strm_wzaes.c
@@ -148,11 +148,10 @@ int32_t mz_stream_wzaes_is_open(void *stream) {
     return MZ_OK;
 }
 
-static int32_t mz_stream_wzaes_ctr_encrypt(void *stream, uint8_t *buf, int32_t size) {
+static int64_t mz_stream_wzaes_ctr_encrypt(void *stream, uint8_t *buf, int64_t size) {
     mz_stream_wzaes *wzaes = (mz_stream_wzaes *)stream;
-    uint32_t pos = wzaes->crypt_pos;
-    uint32_t i = 0;
-    int32_t err = MZ_OK;
+    int64_t pos = wzaes->crypt_pos;
+    int64_t i = 0;
 
     while (i < (uint32_t)size) {
         if (pos == MZ_AES_BLOCK_SIZE) {
@@ -172,7 +171,7 @@ static int32_t mz_stream_wzaes_ctr_encrypt(void *stream, uint8_t *buf, int32_t s
     }
 
     wzaes->crypt_pos = pos;
-    return err;
+    return size;
 }
 
 int64_t mz_stream_wzaes_read(void *stream, void *buf, int64_t size) {

--- a/mz_strm_wzaes.h
+++ b/mz_strm_wzaes.h
@@ -19,10 +19,10 @@ extern "C" {
 
 int32_t mz_stream_wzaes_open(void *stream, const char *filename, int32_t mode);
 int32_t mz_stream_wzaes_is_open(void *stream);
-int32_t mz_stream_wzaes_read(void *stream, void *buf, int32_t size);
-int32_t mz_stream_wzaes_write(void *stream, const void *buf, int32_t size);
+int64_t mz_stream_wzaes_read(void *stream, void *buf, int64_t size);
+int64_t mz_stream_wzaes_write(void *stream, const void *buf, int64_t size);
 int64_t mz_stream_wzaes_tell(void *stream);
-int32_t mz_stream_wzaes_seek(void *stream, int64_t offset, int32_t origin);
+int64_t mz_stream_wzaes_seek(void *stream, int64_t offset, int32_t origin);
 int32_t mz_stream_wzaes_close(void *stream);
 int32_t mz_stream_wzaes_error(void *stream);
 

--- a/mz_strm_zlib.c
+++ b/mz_strm_zlib.c
@@ -126,68 +126,85 @@ int64_t mz_stream_zlib_read(void *stream, void *buf, int64_t size) {
     uint64_t total_out_before = 0;
     uint64_t total_out_after = 0;
     uint32_t total_in = 0;
-    uint32_t total_out = 0;
+    int64_t total_out = 0;
     uint32_t in_bytes = 0;
     uint32_t out_bytes = 0;
     int32_t bytes_to_read = sizeof(zlib->buffer);
     int32_t read = 0;
     int32_t err = Z_OK;
+    unsigned int read_chunk;
+    uint8_t eof = 0;
 
-    zlib->zstream.next_out = (Bytef *)buf;
-    zlib->zstream.avail_out = (uInt)size;
+    if (size < 0)
+        return MZ_PARAM_ERROR;
+    if (size == 0)
+        return 0;
 
-    do {
-        if (zlib->zstream.avail_in == 0) {
-            if (zlib->max_total_in > 0) {
-                if ((int64_t)bytes_to_read > (zlib->max_total_in - zlib->total_in))
-                    bytes_to_read = (int32_t)(zlib->max_total_in - zlib->total_in);
+    while (total_out < size) {
+        read_chunk = (size - total_out > UINT_MAX) ? UINT_MAX : (unsigned int)(size - total_out);
+        zlib->zstream.next_out = (Bytef *)buf + total_out;
+        zlib->zstream.avail_out = read_chunk;
+
+        do {
+            if (zlib->zstream.avail_in == 0 && !eof) {
+                if (zlib->max_total_in > 0) {
+                    if ((int64_t)bytes_to_read > (zlib->max_total_in - zlib->total_in))
+                        bytes_to_read = (int32_t)(zlib->max_total_in - zlib->total_in);
+                }
+                read = mz_stream_read(zlib->stream.base, zlib->buffer, bytes_to_read);
+                if (read < 0)
+                    return read;
+                if (read == 0) {
+                    eof = 1;
+                } else {
+                    zlib->zstream.next_in = zlib->buffer;
+                    zlib->zstream.avail_in = read;
+                }
             }
 
-            read = mz_stream_read(zlib->stream.base, zlib->buffer, bytes_to_read);
+            total_in_before = zlib->zstream.avail_in;
+            total_out_before = zlib->zstream.total_out;
+            err = ZLIB_PREFIX(inflate)(&zlib->zstream, eof ? Z_FINISH : Z_SYNC_FLUSH);
+            if ((err >= Z_OK) && (zlib->zstream.msg)) {
+                zlib->error = Z_DATA_ERROR;
+                break;
+            }
+            total_in_after = zlib->zstream.avail_in;
+            total_out_after = zlib->zstream.total_out;
+            in_bytes = (uint32_t)(total_in_before - total_in_after);
+            out_bytes = (uint32_t)(total_out_after - total_out_before);
+            total_in += in_bytes;
+            total_out += out_bytes;
+            zlib->total_in += in_bytes;
+            zlib->total_out += out_bytes;
 
-            if (read < 0)
-                return read;
+            if (err == Z_STREAM_END)
+                break;
+            if (err != Z_OK) {
+                if (eof && in_bytes == 0 && out_bytes == 0) {
+                    zlib->error = err;
+                    break;
+                }
+                if (!eof) {
+                    zlib->error = err;
+                    break;
+                }
+            }
+            if (eof && zlib->zstream.avail_in == 0 && in_bytes == 0 && out_bytes == 0)
+                break; 
+        } while (zlib->zstream.avail_out > 0);
 
-            zlib->zstream.next_in = zlib->buffer;
-            zlib->zstream.avail_in = read;
-        }
-
-        total_in_before = zlib->zstream.avail_in;
-        total_out_before = zlib->zstream.total_out;
-
-        err = ZLIB_PREFIX(inflate)(&zlib->zstream, Z_SYNC_FLUSH);
-        if ((err >= Z_OK) && (zlib->zstream.msg)) {
-            zlib->error = Z_DATA_ERROR;
+        if (err == Z_STREAM_END || zlib->error != 0)
+            break; 
+        if (eof && zlib->zstream.avail_in == 0)
             break;
-        }
-
-        total_in_after = zlib->zstream.avail_in;
-        total_out_after = zlib->zstream.total_out;
-
-        in_bytes = (uint32_t)(total_in_before - total_in_after);
-        out_bytes = (uint32_t)(total_out_after - total_out_before);
-
-        total_in += in_bytes;
-        total_out += out_bytes;
-
-        zlib->total_in += in_bytes;
-        zlib->total_out += out_bytes;
-
-        if (err == Z_STREAM_END)
-            break;
-        if (err != Z_OK) {
-            zlib->error = err;
-            break;
-        }
-    } while (zlib->zstream.avail_out > 0);
+    }
 
     MZ_UNUSED(total_in);
-
     if (zlib->error != 0) {
         /* Zlib errors are compatible with MZ */
         return zlib->error;
     }
-
     return total_out;
 #endif
 }

--- a/mz_strm_zlib.c
+++ b/mz_strm_zlib.c
@@ -113,7 +113,7 @@ int32_t mz_stream_zlib_is_open(void *stream) {
     return MZ_OK;
 }
 
-int32_t mz_stream_zlib_read(void *stream, void *buf, int32_t size) {
+int64_t mz_stream_zlib_read(void *stream, void *buf, int64_t size) {
 #ifdef MZ_ZIP_NO_DECOMPRESSION
     MZ_UNUSED(stream);
     MZ_UNUSED(buf);
@@ -240,7 +240,7 @@ static int32_t mz_stream_zlib_deflate(void *stream, int flush) {
 }
 #endif
 
-int32_t mz_stream_zlib_write(void *stream, const void *buf, int32_t size) {
+int64_t mz_stream_zlib_write(void *stream, const void *buf, int64_t size) {
 #ifdef MZ_ZIP_NO_COMPRESSION
     MZ_UNUSED(stream);
     MZ_UNUSED(buf);
@@ -269,7 +269,7 @@ int64_t mz_stream_zlib_tell(void *stream) {
     return MZ_TELL_ERROR;
 }
 
-int32_t mz_stream_zlib_seek(void *stream, int64_t offset, int32_t origin) {
+int64_t mz_stream_zlib_seek(void *stream, int64_t offset, int32_t origin) {
     MZ_UNUSED(stream);
     MZ_UNUSED(offset);
     MZ_UNUSED(origin);

--- a/mz_strm_zlib.h
+++ b/mz_strm_zlib.h
@@ -19,10 +19,10 @@ extern "C" {
 
 int32_t mz_stream_zlib_open(void *stream, const char *filename, int32_t mode);
 int32_t mz_stream_zlib_is_open(void *stream);
-int32_t mz_stream_zlib_read(void *stream, void *buf, int32_t size);
-int32_t mz_stream_zlib_write(void *stream, const void *buf, int32_t size);
+int64_t mz_stream_zlib_read(void *stream, void *buf, int64_t size);
+int64_t mz_stream_zlib_write(void *stream, const void *buf, int64_t size);
 int64_t mz_stream_zlib_tell(void *stream);
-int32_t mz_stream_zlib_seek(void *stream, int64_t offset, int32_t origin);
+int64_t mz_stream_zlib_seek(void *stream, int64_t offset, int32_t origin);
 int32_t mz_stream_zlib_close(void *stream);
 int32_t mz_stream_zlib_error(void *stream);
 

--- a/mz_strm_zstd.c
+++ b/mz_strm_zstd.c
@@ -85,7 +85,7 @@ int32_t mz_stream_zstd_is_open(void *stream) {
     return MZ_OK;
 }
 
-int32_t mz_stream_zstd_read(void *stream, void *buf, int32_t size) {
+int64_t mz_stream_zstd_read(void *stream, void *buf, int64_t size) {
 #ifdef MZ_ZIP_NO_DECOMPRESSION
     MZ_UNUSED(stream);
     MZ_UNUSED(buf);
@@ -204,7 +204,7 @@ static int32_t mz_stream_zstd_compress(void *stream, ZSTD_EndDirective flush) {
 }
 #endif
 
-int32_t mz_stream_zstd_write(void *stream, const void *buf, int32_t size) {
+int64_t mz_stream_zstd_write(void *stream, const void *buf, int64_t size) {
 #ifdef MZ_ZIP_NO_COMPRESSION
     MZ_UNUSED(stream);
     MZ_UNUSED(buf);
@@ -234,7 +234,7 @@ int64_t mz_stream_zstd_tell(void *stream) {
     return MZ_TELL_ERROR;
 }
 
-int32_t mz_stream_zstd_seek(void *stream, int64_t offset, int32_t origin) {
+int64_t mz_stream_zstd_seek(void *stream, int64_t offset, int32_t origin) {
     MZ_UNUSED(stream);
     MZ_UNUSED(offset);
     MZ_UNUSED(origin);

--- a/mz_strm_zstd.c
+++ b/mz_strm_zstd.c
@@ -164,7 +164,10 @@ int64_t mz_stream_zstd_read(void *stream, void *buf, int64_t size) {
                 return MZ_DATA_ERROR;
             }
             if (result == 0)
+            {
+                frame_done = 1;
                 zstd->stream_end = 1;
+            }
 
             total_in_after = zstd->in.pos;
             total_out_after = zstd->out.pos;

--- a/mz_strm_zstd.c
+++ b/mz_strm_zstd.c
@@ -41,6 +41,7 @@ typedef struct mz_stream_zstd_s {
     int64_t max_total_out;
     int8_t initialized;
     int32_t preset;
+    int8_t stream_end;
 } mz_stream_zstd;
 
 /***************************************************************************/
@@ -98,6 +99,7 @@ int64_t mz_stream_zstd_read(void *stream, void *buf, int64_t size) {
     uint64_t total_out_before = 0;
     uint64_t total_out_after = 0;
     int64_t total_out = 0;
+    int64_t out_limit = 0;
     int32_t in_bytes = 0;
     int32_t out_bytes = 0;
     int32_t bytes_to_read = sizeof(zstd->buffer);
@@ -114,6 +116,15 @@ int64_t mz_stream_zstd_read(void *stream, void *buf, int64_t size) {
 
     while (total_out < size) {
         chunk_size = ((size - total_out) > (int64_t)SIZE_MAX) ? SIZE_MAX : (size_t)(size - total_out);
+
+        if (zstd->max_total_out != -1) {
+            out_limit = zstd->max_total_out - zstd->total_out;
+            if (out_limit <= 0)
+                break;
+            if ((int64_t)chunk_size > out_limit)
+                chunk_size = (size_t)out_limit;
+        }
+
         zstd->out.dst = (void *)((uint8_t *)buf + total_out);
         zstd->out.size = chunk_size;
         zstd->out.pos = 0;
@@ -153,7 +164,7 @@ int64_t mz_stream_zstd_read(void *stream, void *buf, int64_t size) {
                 return MZ_DATA_ERROR;
             }
             if (result == 0)
-                frame_done = 1; /* ZSTD_decompressStream signals frame completion */
+                zstd->stream_end = 1;
 
             total_in_after = zstd->in.pos;
             total_out_after = zstd->out.pos;
@@ -165,7 +176,7 @@ int64_t mz_stream_zstd_read(void *stream, void *buf, int64_t size) {
             zstd->total_in += in_bytes;
             zstd->total_out += out_bytes;
 
-            if (frame_done)
+            if (zstd->stream_end)
                 break;
 
             /* No progress at all and no more input coming: stop instead of spinning. */

--- a/mz_strm_zstd.c
+++ b/mz_strm_zstd.c
@@ -97,58 +97,94 @@ int64_t mz_stream_zstd_read(void *stream, void *buf, int64_t size) {
     uint64_t total_in_after = 0;
     uint64_t total_out_before = 0;
     uint64_t total_out_after = 0;
-    int32_t total_out = 0;
+    int64_t total_out = 0;
     int32_t in_bytes = 0;
     int32_t out_bytes = 0;
     int32_t bytes_to_read = sizeof(zstd->buffer);
     int32_t read = 0;
     size_t result = 0;
+    size_t chunk_size = 0;
+    uint8_t eof = 0;
+    uint8_t frame_done = 0;
 
-    zstd->out.dst = (void *)buf;
-    zstd->out.size = (size_t)size;
-    zstd->out.pos = 0;
+    if (size < 0)
+        return MZ_PARAM_ERROR;
+    if (size == 0)
+        return 0;
 
-    do {
-        if (zstd->in.pos == zstd->in.size) {
-            if (zstd->max_total_in > 0) {
-                if ((int64_t)bytes_to_read > (zstd->max_total_in - zstd->total_in))
-                    bytes_to_read = (int32_t)(zstd->max_total_in - zstd->total_in);
+    while (total_out < size) {
+        chunk_size = ((size - total_out) > (int64_t)SIZE_MAX) ? SIZE_MAX : (size_t)(size - total_out);
+        zstd->out.dst = (void *)((uint8_t *)buf + total_out);
+        zstd->out.size = chunk_size;
+        zstd->out.pos = 0;
+
+        do {
+            if (zstd->in.pos == zstd->in.size && !eof) {
+                if (zstd->max_total_in > 0) {
+                    if ((int64_t)bytes_to_read > (zstd->max_total_in - zstd->total_in))
+                        bytes_to_read = (int32_t)(zstd->max_total_in - zstd->total_in);
+                }
+                read = mz_stream_read(zstd->stream.base, zstd->buffer, bytes_to_read);
+                if (read < 0)
+                    return read;
+                if (read == 0) {
+                    eof = 1;
+                } else {
+                    zstd->in.src = (const void *)zstd->buffer;
+                    zstd->in.pos = 0;
+                    zstd->in.size = (size_t)read;
+                }
             }
 
-            read = mz_stream_read(zstd->stream.base, zstd->buffer, bytes_to_read);
+            if (zstd->in.pos == zstd->in.size && eof) {
+                /* No more input available at all. If we haven't finished a
+                   frame yet, this is truncated/corrupt data. */
+                if (!frame_done && total_out < size && zstd->out.pos == 0) {
+                    /* No progress possible; break out without spinning. */
+                }
+                break;
+            }
 
-            if (read < 0)
-                return read;
+            total_in_before = zstd->in.pos;
+            total_out_before = zstd->out.pos;
+            result = ZSTD_decompressStream(zstd->zdstream, &zstd->out, &zstd->in);
+            if (ZSTD_isError(result)) {
+                zstd->error = (int32_t)result;
+                return MZ_DATA_ERROR;
+            }
+            if (result == 0)
+                frame_done = 1; /* ZSTD_decompressStream signals frame completion */
 
-            zstd->in.src = (const void *)zstd->buffer;
-            zstd->in.pos = 0;
-            zstd->in.size = (size_t)read;
-        }
+            total_in_after = zstd->in.pos;
+            total_out_after = zstd->out.pos;
+            if ((zstd->max_total_out != -1) && (int64_t)total_out_after + total_out > zstd->max_total_out)
+                break;
+            in_bytes = (int32_t)(total_in_after - total_in_before);
+            out_bytes = (int32_t)(total_out_after - total_out_before);
+            total_out += out_bytes;
+            zstd->total_in += in_bytes;
+            zstd->total_out += out_bytes;
 
-        total_in_before = zstd->in.pos;
-        total_out_before = zstd->out.pos;
+            if (frame_done)
+                break;
 
-        result = ZSTD_decompressStream(zstd->zdstream, &zstd->out, &zstd->in);
+            /* No progress at all and no more input coming: stop instead of spinning. */
+            if (eof && in_bytes == 0 && out_bytes == 0)
+                break;
+        } while ((zstd->in.size > 0 || out_bytes > 0) && (zstd->out.pos < zstd->out.size));
 
-        if (ZSTD_isError(result)) {
-            zstd->error = (int32_t)result;
-            return MZ_DATA_ERROR;
-        }
+        if (frame_done)
+            break; /* stop the outer loop too once the frame is fully decoded */
+        if (eof && zstd->in.pos == zstd->in.size)
+            break; /* input exhausted, nothing more we can do */
+    }
 
-        total_in_after = zstd->in.pos;
-        total_out_after = zstd->out.pos;
-        if ((zstd->max_total_out != -1) && (int64_t)total_out_after > zstd->max_total_out)
-            total_out_after = (uint64_t)zstd->max_total_out;
-
-        in_bytes = (int32_t)(total_in_after - total_in_before);
-        out_bytes = (int32_t)(total_out_after - total_out_before);
-
-        total_out += out_bytes;
-
-        zstd->total_in += in_bytes;
-        zstd->total_out += out_bytes;
-
-    } while ((zstd->in.size > 0 || out_bytes > 0) && (zstd->out.pos < zstd->out.size));
+    if (!frame_done && eof && total_out < size) {
+        /* Ran out of input before completing the frame and before
+           satisfying the requested size: truncated/corrupt stream. */
+        zstd->error = 1;
+        return MZ_DATA_ERROR;
+    }
 
     return total_out;
 #endif
@@ -213,21 +249,35 @@ int64_t mz_stream_zstd_write(void *stream, const void *buf, int64_t size) {
 #else
     mz_stream_zstd *zstd = (mz_stream_zstd *)stream;
     int32_t err = MZ_OK;
+    int64_t total_written = 0;
+    size_t write_chunk = 0;
 
-    zstd->in.src = buf;
-    zstd->in.pos = 0;
-    zstd->in.size = size;
+    if (size < 0)
+        return MZ_PARAM_ERROR;
 
-    err = mz_stream_zstd_compress(stream, ZSTD_e_continue);
-    if (err != MZ_OK) {
-        return err;
+    if (size == 0)
+        return 0;
+
+    while (total_written < size)
+    {
+        write_chunk = (size - total_written > SIZE_MAX) ? SIZE_MAX : (size_t)(size - total_written);
+        zstd->in.src = (uint8_t *)buf + total_written;
+        zstd->in.pos = 0;
+        zstd->in.size = write_chunk;
+
+        err = mz_stream_zstd_compress(stream, ZSTD_e_continue);
+        if (err != MZ_OK) {
+            return err;
+        }
+
+        total_written += write_chunk;
+        zstd->total_in += write_chunk;
     }
 
-    zstd->total_in += size;
-    return size;
-#endif
+    return total_written;
 }
 
+#endif
 int64_t mz_stream_zstd_tell(void *stream) {
     MZ_UNUSED(stream);
 

--- a/mz_strm_zstd.h
+++ b/mz_strm_zstd.h
@@ -20,10 +20,10 @@ extern "C" {
 
 int32_t mz_stream_zstd_open(void *stream, const char *filename, int32_t mode);
 int32_t mz_stream_zstd_is_open(void *stream);
-int32_t mz_stream_zstd_read(void *stream, void *buf, int32_t size);
-int32_t mz_stream_zstd_write(void *stream, const void *buf, int32_t size);
+int64_t mz_stream_zstd_read(void *stream, void *buf, int64_t size);
+int64_t mz_stream_zstd_write(void *stream, const void *buf, int64_t size);
 int64_t mz_stream_zstd_tell(void *stream);
-int32_t mz_stream_zstd_seek(void *stream, int64_t offset, int32_t origin);
+int64_t mz_stream_zstd_seek(void *stream, int64_t offset, int32_t origin);
 int32_t mz_stream_zstd_close(void *stream);
 int32_t mz_stream_zstd_error(void *stream);
 

--- a/mz_zip.c
+++ b/mz_zip.c
@@ -2045,7 +2045,7 @@ int32_t mz_zip_entry_write_open(void *handle, const mz_zip_file *file_info, int1
     return err;
 }
 
-int32_t mz_zip_entry_read(void *handle, void *buf, int32_t len) {
+int64_t mz_zip_entry_read(void *handle, void *buf, int64_t len) {
     mz_zip *zip = (mz_zip *)handle;
     int32_t read = 0;
 

--- a/mz_zip.c
+++ b/mz_zip.c
@@ -2100,7 +2100,7 @@ int64_t mz_zip_entry_write(void *handle, const void *buf, int64_t len) {
         while(total_written < written)
         {
             write_chunk = (len > UINT32_MAX) ? UINT32_MAX : (uint32_t)(written - total_written);
-            zip->entry_crc32 = mz_crypt_crc32_update(zip->entry_crc32, buf, written);
+            zip->entry_crc32 = mz_crypt_crc32_update(zip->entry_crc32, buf_ptr, write_chunk);
             buf_ptr += write_chunk;
             total_written += write_chunk;
         }

--- a/mz_zip.c
+++ b/mz_zip.c
@@ -2045,15 +2045,22 @@ int32_t mz_zip_entry_write_open(void *handle, const mz_zip_file *file_info, int1
     return err;
 }
 
+//TODO issue744 zip->entry_crc32 and mz_crypt_crc32_update for now left 32bit
 int64_t mz_zip_entry_read(void *handle, void *buf, int64_t len) {
     mz_zip *zip = (mz_zip *)handle;
-    int32_t read = 0;
+    int64_t read = 0;
+    int64_t total_read = 0;
+    uint32_t read_chunk = 0;
+    uint8_t *buf_ptr = buf;
+
+    if (len > INT32_MAX)
+        return MZ_PARAM_ERROR;
 
     if (!zip || mz_zip_entry_is_open(zip) != MZ_OK)
         return MZ_PARAM_ERROR;
     if (UINT_MAX == UINT16_MAX && len > UINT16_MAX) /* zlib limitation */
         return MZ_PARAM_ERROR;
-    if (len == 0)
+    if (len <= 0)
         return MZ_PARAM_ERROR;
 
     if (zip->file_info.compressed_size == 0)
@@ -2063,24 +2070,43 @@ int64_t mz_zip_entry_read(void *handle, void *buf, int64_t len) {
     /* aes encryption validation will fail if compressed_size > 0 */
     read = mz_stream_read(zip->compress_stream, buf, len);
     if (read > 0)
-        zip->entry_crc32 = mz_crypt_crc32_update(zip->entry_crc32, buf, read);
+    {
+        while(total_read < read)
+        {
+            read_chunk = (len > UINT32_MAX) ? UINT32_MAX : (uint32_t)(read - total_read);
+            zip->entry_crc32 = mz_crypt_crc32_update(zip->entry_crc32, buf_ptr, read_chunk);
+            buf_ptr += read_chunk;
+            total_read += read_chunk;
+        }
+    }
 
-    mz_zip_print("Zip - Entry - Read - %" PRId32 " (max %" PRId32 ")\n", read, len);
+    mz_zip_print("Zip - Entry - Read - %" PRId64 " (max %" PRId64 ")\n", read, len);
 
     return read;
 }
 
-int32_t mz_zip_entry_write(void *handle, const void *buf, int32_t len) {
+int64_t mz_zip_entry_write(void *handle, const void *buf, int64_t len) {
     mz_zip *zip = (mz_zip *)handle;
-    int32_t written = 0;
+    int64_t written = 0;
+    int64_t total_written = 0;
+    uint32_t write_chunk = 0;
+    const uint8_t *buf_ptr = buf;
 
     if (!zip || mz_zip_entry_is_open(zip) != MZ_OK)
         return MZ_PARAM_ERROR;
     written = mz_stream_write(zip->compress_stream, buf, len);
     if (written > 0)
-        zip->entry_crc32 = mz_crypt_crc32_update(zip->entry_crc32, buf, written);
+    {
+        while(total_written < written)
+        {
+            write_chunk = (len > UINT32_MAX) ? UINT32_MAX : (uint32_t)(written - total_written);
+            zip->entry_crc32 = mz_crypt_crc32_update(zip->entry_crc32, buf, written);
+            buf_ptr += write_chunk;
+            total_written += write_chunk;
+        }
+    }
 
-    mz_zip_print("Zip - Entry - Write - %" PRId32 " (max %" PRId32 ")\n", written, len);
+    mz_zip_print("Zip - Entry - Write - %" PRId64 " (max %" PRId64 ")\n", written, len);
     return written;
 }
 

--- a/mz_zip.h
+++ b/mz_zip.h
@@ -115,7 +115,7 @@ int32_t mz_zip_entry_is_open(void *handle);
 int32_t mz_zip_entry_read_open(void *handle, uint8_t raw, const char *password);
 /* Open for reading the current file in the zip file */
 
-int32_t mz_zip_entry_read(void *handle, void *buf, int32_t len);
+int64_t mz_zip_entry_read(void *handle, void *buf, int64_t len);
 /* Read bytes from the current file in the zip file */
 
 int32_t mz_zip_entry_read_close(void *handle, uint32_t *crc32, int64_t *compressed_size, int64_t *uncompressed_size);

--- a/mz_zip.h
+++ b/mz_zip.h
@@ -125,7 +125,7 @@ int32_t mz_zip_entry_write_open(void *handle, const mz_zip_file *file_info, int1
                                 const char *password);
 /* Open for writing the current file in the zip file */
 
-int32_t mz_zip_entry_write(void *handle, const void *buf, int32_t len);
+int64_t mz_zip_entry_write(void *handle, const void *buf, int64_t len);
 /* Write bytes from the current file in the zip file */
 
 int32_t mz_zip_entry_write_close(void *handle, uint32_t crc32, int64_t compressed_size, int64_t uncompressed_size);

--- a/mz_zip_rw.c
+++ b/mz_zip_rw.c
@@ -1117,7 +1117,7 @@ int32_t mz_zip_writer_zip_cd(void *handle) {
     uint64_t number_entry = 0;
     int64_t cd_mem_length = 0;
     int32_t err = MZ_OK;
-    int32_t extrafield_size = 0;
+    int64_t extrafield_size = 0;
     void *file_extra_stream = NULL;
     void *cd_mem_stream = NULL;
 
@@ -1150,7 +1150,7 @@ int32_t mz_zip_writer_zip_cd(void *handle) {
     mz_stream_write_uint64(file_extra_stream, number_entry);
 
     mz_stream_mem_get_buffer(file_extra_stream, (const void **)&cd_file.extrafield);
-    mz_stream_mem_get_buffer_length(file_extra_stream, (int64_t *)&extrafield_size);
+    mz_stream_mem_get_buffer_length(file_extra_stream, &extrafield_size);
     cd_file.extrafield_size = (uint16_t)extrafield_size;
 
     err = mz_zip_writer_entry_open(writer, &cd_file);
@@ -1418,7 +1418,7 @@ int32_t mz_zip_writer_entry_close(void *handle) {
     int32_t err = MZ_OK;
 #ifndef MZ_ZIP_NO_CRYPTO
     const uint8_t *extrafield = NULL;
-    int32_t extrafield_size = 0;
+    int64_t extrafield_size = 0;
     int16_t field_length_hash = 0;
     uint8_t hash_digest[MZ_HASH_MAX_SIZE];
 #endif
@@ -1469,7 +1469,7 @@ int32_t mz_zip_writer_entry_close(void *handle) {
 
         /* Update extra field for central directory after adding extra fields */
         mz_stream_mem_get_buffer(writer->file_extra_stream, (const void **)&extrafield);
-        mz_stream_mem_get_buffer_length(writer->file_extra_stream, (int64_t *)&extrafield_size);
+        mz_stream_mem_get_buffer_length(writer->file_extra_stream, &extrafield_size);
 
         mz_zip_entry_set_extrafield(writer->zip_handle, extrafield, (uint16_t)extrafield_size);
     }

--- a/mz_zip_rw.c
+++ b/mz_zip_rw.c
@@ -471,7 +471,7 @@ int32_t mz_zip_reader_entry_close(void *handle) {
     return err;
 }
 
-int32_t mz_zip_reader_entry_read(void *handle, void *buf, int32_t len) {
+int64_t mz_zip_reader_entry_read(void *handle, void *buf, int64_t len) {
     mz_zip_reader *reader = (mz_zip_reader *)handle;
     int32_t read = 0;
     if (!reader)
@@ -1150,7 +1150,7 @@ int32_t mz_zip_writer_zip_cd(void *handle) {
     mz_stream_write_uint64(file_extra_stream, number_entry);
 
     mz_stream_mem_get_buffer(file_extra_stream, (const void **)&cd_file.extrafield);
-    mz_stream_mem_get_buffer_length(file_extra_stream, &extrafield_size);
+    mz_stream_mem_get_buffer_length(file_extra_stream, (int64_t *)&extrafield_size);
     cd_file.extrafield_size = (uint16_t)extrafield_size;
 
     err = mz_zip_writer_entry_open(writer, &cd_file);
@@ -1469,7 +1469,7 @@ int32_t mz_zip_writer_entry_close(void *handle) {
 
         /* Update extra field for central directory after adding extra fields */
         mz_stream_mem_get_buffer(writer->file_extra_stream, (const void **)&extrafield);
-        mz_stream_mem_get_buffer_length(writer->file_extra_stream, &extrafield_size);
+        mz_stream_mem_get_buffer_length(writer->file_extra_stream, (int64_t *)&extrafield_size);
 
         mz_zip_entry_set_extrafield(writer->zip_handle, extrafield, (uint16_t)extrafield_size);
     }
@@ -1489,7 +1489,7 @@ int32_t mz_zip_writer_entry_close(void *handle) {
     return err;
 }
 
-int32_t mz_zip_writer_entry_write(void *handle, const void *buf, int32_t len) {
+int64_t mz_zip_writer_entry_write(void *handle, const void *buf, int64_t len) {
     mz_zip_writer *writer = (mz_zip_writer *)handle;
     int32_t written = 0;
     if (!writer)

--- a/mz_zip_rw.c
+++ b/mz_zip_rw.c
@@ -1491,7 +1491,7 @@ int32_t mz_zip_writer_entry_close(void *handle) {
 
 int64_t mz_zip_writer_entry_write(void *handle, const void *buf, int64_t len) {
     mz_zip_writer *writer = (mz_zip_writer *)handle;
-    int32_t written = 0;
+    int64_t written = 0;
     if (!writer)
         return MZ_PARAM_ERROR;
     written = mz_zip_entry_write(writer->zip_handle, buf, len);

--- a/mz_zip_rw.h
+++ b/mz_zip_rw.h
@@ -65,7 +65,7 @@ int32_t mz_zip_reader_entry_open(void *handle);
 int32_t mz_zip_reader_entry_close(void *handle);
 /* Closes an entry */
 
-int32_t mz_zip_reader_entry_read(void *handle, void *buf, int32_t len);
+int64_t mz_zip_reader_entry_read(void *handle, void *buf, int64_t len);
 /* Reads an entry after being opened */
 
 int32_t mz_zip_reader_entry_get_hash(void *handle, uint16_t algorithm, uint8_t *digest, int32_t digest_size);
@@ -183,7 +183,7 @@ int32_t mz_zip_writer_entry_open(void *handle, mz_zip_file *file_info);
 int32_t mz_zip_writer_entry_close(void *handle);
 /* Closes entry in zip file */
 
-int32_t mz_zip_writer_entry_write(void *handle, const void *buf, int32_t len);
+int64_t mz_zip_writer_entry_write(void *handle, const void *buf, int64_t len);
 /* Writes data into entry for zip */
 
 /***************************************************************************/


### PR DESCRIPTION
### Changes:
- Changed struct fields types to int64_t to support bigger buffer sizes
- Fully implemented logic for int64_t for mz_strm_mem
- Fixed memcpy bugs in mz_strm_mem.c
- Fixed mem->limit bugs
- added additional checks for allocations
- Updated stream interface callbacks for valid return values in read, write and seek

### Note: 
Other stream implementations had their function signatures updated to match the new vtable (because they implement the same interface), but their internal logic was **not** changed in this PR (they still operate with 32-bit limits). A follow-up PR can extend full int64_t support to them if desired.


### Tests:
- Built successfully
- minizip_test passes
