### PR TITLE
cmake: option MZ_PBKDF2: export mz_crypt_pbkdf2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,7 @@ option(MZ_FORCE_FETCH_LIBS "Enables fetching third-party libraries always" OFF)
 option(MZ_PKCRYPT "Enables PKWARE traditional encryption" ON)
 option(MZ_WZAES "Enables WinZIP AES encryption" ON)
 option(MZ_OPENSSL "Enables OpenSSL for encryption" ${UNIX})
+option(MZ_PBKDF2 "Enables Password-Based Key Derivation Function 2" OFF)
 cmake_dependent_option(MZ_LIBBSD "Builds with libbsd crypto random" ON "UNIX" OFF)
 # Character conversion options
 option(MZ_ICONV "Enables iconv for string encoding conversion" ON)
@@ -607,7 +608,15 @@ else()
     endif()
 endif()
 
+if(MZ_WZAES)
+    # WinZIP AES encryption requires PBKDF2
+    set(MZ_PBKDF2 ON)
+endif()
+
 # Setup predefined macros
+if(MZ_PBKDF2)
+    list(APPEND MINIZIP_DEF -DHAVE_PBKDF2)
+endif()
 if(MZ_COMPRESS_ONLY)
     list(APPEND MINIZIP_DEF -DMZ_ZIP_NO_DECOMPRESSION)
 endif()

--- a/mz_crypt.c
+++ b/mz_crypt.c
@@ -91,7 +91,7 @@ uint32_t mz_crypt_crc32_update(uint32_t value, const uint8_t *buf, int32_t size)
 #endif
 }
 
-#if defined(HAVE_WZAES)
+#if defined(HAVE_PBKDF2)
 int32_t mz_crypt_pbkdf2(const uint8_t *password, int32_t password_length, const uint8_t *salt, int32_t salt_length,
                         uint32_t iteration_count, uint8_t *key, uint16_t key_length) {
     void *hmac1 = NULL;


### PR DESCRIPTION
Let users use the function if they implement `mz_crypt_hmac_*` API without using CommonCrypto or OpenSSL.