### PR TITLE
Support custom memory allocation functions like zlib-ng

### DIFF
--- a/compat/ioapi.c
+++ b/compat/ioapi.c
@@ -200,7 +200,7 @@ int32_t mz_stream_ioapi_set_filefunc64(void *stream, zlib_filefunc64_def *filefu
 }
 
 void *mz_stream_ioapi_create(void) {
-    mz_stream_ioapi *ioapi = (mz_stream_ioapi *)calloc(1, sizeof(mz_stream_ioapi));
+    mz_stream_ioapi *ioapi = (mz_stream_ioapi *)MZ_ALLOC(&mz_global_calloc, 1, (uint32_t)sizeof(mz_stream_ioapi));
     if (ioapi)
         ioapi->stream.vtbl = &mz_stream_ioapi_vtbl;
     return ioapi;
@@ -211,7 +211,7 @@ void mz_stream_ioapi_delete(void **stream) {
     if (!stream)
         return;
     ioapi = (mz_stream_ioapi *)*stream;
-    MZ_FREE((mz_stream *)ioapi, ioapi);
+    MZ_FREE(&mz_global_calloc, ioapi);
     *stream = NULL;
 }
 

--- a/compat/ioapi.c
+++ b/compat/ioapi.c
@@ -211,7 +211,7 @@ void mz_stream_ioapi_delete(void **stream) {
     if (!stream)
         return;
     ioapi = (mz_stream_ioapi *)*stream;
-    free(ioapi);
+    MZ_FREE((mz_stream *)ioapi, ioapi);
     *stream = NULL;
 }
 

--- a/compat/unzip.c
+++ b/compat/unzip.c
@@ -28,6 +28,11 @@ typedef struct mz_unzip_compat_s {
     uint64_t entry_index;
     int64_t entry_pos;
     int64_t total_out;
+    mz_alloc_func alloc_cb;
+    mz_free_func free_cb;
+    mz_realloc_func realloc_cb;
+    mz_strdup_func strdup_cb;
+    void *opaque;
 } mz_unzip_compat;
 
 /***************************************************************************/
@@ -173,7 +178,7 @@ int unzClose(unzFile file) {
         mz_stream_delete(&compat->stream);
     }
 
-    free(compat);
+    MZ_FREE(compat, compat);
 
     return err;
 }

--- a/compat/unzip.c
+++ b/compat/unzip.c
@@ -150,10 +150,15 @@ unzFile unzOpen_MZ(void *stream) {
         return NULL;
     }
 
-    compat = (mz_unzip_compat *)calloc(1, sizeof(mz_unzip_compat));
+    compat = (mz_unzip_compat *)MZ_ALLOC(&mz_global_calloc, 1, (uint32_t)sizeof(mz_unzip_compat));
     if (compat) {
         compat->handle = handle;
         compat->stream = stream;
+        compat->alloc_cb = NULL;
+        compat->free_cb = NULL;
+        compat->realloc_cb = NULL;
+        compat->strdup_cb = NULL;
+        compat->opaque = NULL;
 
         mz_zip_goto_first_entry(compat->handle);
     } else {
@@ -178,7 +183,7 @@ int unzClose(unzFile file) {
         mz_stream_delete(&compat->stream);
     }
 
-    MZ_FREE(compat, compat);
+    MZ_FREE(&mz_global_calloc, compat);
 
     return err;
 }

--- a/compat/zip.c
+++ b/compat/zip.c
@@ -23,6 +23,11 @@
 typedef struct mz_zip_compat_s {
     void *stream;
     void *handle;
+    mz_alloc_func alloc_cb;
+    mz_free_func free_cb;
+    mz_realloc_func realloc_cb;
+    mz_strdup_func strdup_cb;
+    void *opaque;
 } mz_zip_compat;
 
 /***************************************************************************/
@@ -376,7 +381,7 @@ int zipClose2_64(zipFile file, const char *global_comment, uint16_t version_made
         mz_stream_delete(&compat->stream);
     }
 
-    free(compat);
+    MZ_FREE(compat, compat);
 
     return err;
 }

--- a/compat/zip.c
+++ b/compat/zip.c
@@ -154,10 +154,15 @@ zipFile zipOpen_MZ(void *stream, int append, zipcharpc *globalcomment) {
     if (globalcomment)
         mz_zip_get_comment(handle, globalcomment);
 
-    compat = (mz_zip_compat *)calloc(1, sizeof(mz_zip_compat));
+    compat = (mz_zip_compat *)MZ_ALLOC(&mz_global_calloc, 1, (uint32_t)sizeof(mz_zip_compat));
     if (compat) {
         compat->handle = handle;
         compat->stream = stream;
+        compat->alloc_cb = NULL;
+        compat->free_cb = NULL;
+        compat->realloc_cb = NULL;
+        compat->strdup_cb = NULL;
+        compat->opaque = NULL;
     } else {
         mz_zip_delete(&handle);
     }
@@ -381,7 +386,7 @@ int zipClose2_64(zipFile file, const char *global_comment, uint16_t version_made
         mz_stream_delete(&compat->stream);
     }
 
-    MZ_FREE(compat, compat);
+    MZ_FREE(&mz_global_calloc, compat);
 
     return err;
 }

--- a/doc/README.md
+++ b/doc/README.md
@@ -14,6 +14,7 @@
   - [Buffered Stream](#buffered-stream)
   - [Disk Splitting Stream](#disk-splitting-stream)
   - [Additional Code Examples](#additional-code-examples)
+- [Custom Memory Allocation](#custom-memory-allocation)
 
 ## API
 
@@ -265,3 +266,56 @@ Some of these may be out of date, but they can also be helpful.
 * [Compressed stream tests](https://github.com/zlib-ng/minizip-ng/blob/master/test/test_stream_compress.cc)
 * [Code to copy raw entries from one zip file to another](https://gist.github.com/chenxiaolong/bcbb0835182ef16a25f09db8d99e0619) by chenxiaolong
 * [Buffered streaming](https://gist.github.com/chenxiaolong/dbab3fbef51b9d0fa969e220dbb85967) by chenxiaolong
+
+## Custom Memory Allocation
+
+Custom memory allocation functions can be set on stream and zip objects, similar to zlib-ng's `zalloc`/`zfree` mechanism. If not set, the default C standard library allocators (`calloc`, `free`, `realloc`, `malloc`-based `strdup`) are used.
+
+### Types
+
+```c
+typedef void *(*mz_alloc_func)(void *opaque, uint32_t items, uint32_t size);
+typedef void  (*mz_free_func)(void *opaque, void *address);
+typedef void *(*mz_realloc_func)(void *opaque, void *address, uint32_t items, uint32_t size);
+typedef char *(*mz_strdup_func)(void *opaque, const char *str);
+```
+
+### Stream allocators
+
+```c
+void *mem_stream = mz_stream_mem_create();
+mz_stream_set_alloc_funcs(mem_stream, my_alloc, my_free, NULL, NULL, &my_data);
+/* All subsequent allocations in this stream use the custom allocators */
+```
+
+### Zip handle allocators
+
+```c
+void *zip_handle = mz_zip_create();
+mz_zip_set_alloc_funcs(zip_handle, my_alloc, my_free, NULL, NULL, &my_data);
+```
+
+### Zip reader/writer allocators
+
+```c
+mz_zip_reader_set_alloc_funcs(reader, my_alloc, my_free, my_realloc, my_strdup, &my_data);
+mz_zip_writer_set_alloc_funcs(writer, my_alloc, my_free, my_realloc, my_strdup, &my_data);
+```
+
+### Example
+
+```c
+void *my_alloc(void *opaque, uint32_t items, uint32_t size) {
+    return calloc(items, size);
+}
+
+void my_free(void *opaque, void *ptr) {
+    free(ptr);
+}
+
+void *zip = mz_zip_create();
+mz_zip_set_alloc_funcs(zip, my_alloc, my_free, NULL, NULL, NULL);
+
+void *stream = mz_stream_zlib_create();
+mz_stream_set_alloc_funcs(stream, my_alloc, my_free, NULL, NULL, NULL);
+```

--- a/mz.h
+++ b/mz.h
@@ -317,7 +317,7 @@ static inline char *mz_default_strdup(void *opaque, const char *str) {
             if ((handle)->free_cb)                                                                                     \
                 (handle)->free_cb((handle)->opaque, (address));                                                        \
             else                                                                                                       \
-                mz_default_free(NULL, (address));                                                                      \
+                mz_default_free((handle)->opaque, (address));                                                          \
         }                                                                                                              \
     } while (0)
 
@@ -327,6 +327,21 @@ static inline char *mz_default_strdup(void *opaque, const char *str) {
 
 #define MZ_STRDUP(handle, str)                                                                                         \
     ((handle)->strdup_cb ? (handle)->strdup_cb((handle)->opaque, str) : mz_default_strdup((handle)->opaque, str))
+
+/***************************************************************************/
+
+typedef struct mz_calloc_s {
+    mz_alloc_func alloc_cb;
+    mz_free_func free_cb;
+    mz_realloc_func realloc_cb;
+    mz_strdup_func strdup_cb;
+    void *opaque;
+} mz_calloc;
+
+extern mz_calloc mz_global_calloc;
+
+void mz_set_default_alloc_funcs(mz_alloc_func alloc, mz_free_func free_fn, mz_realloc_func realloc_fn,
+                                mz_strdup_func strdup_fn, void *opaque);
 
 /***************************************************************************/
 

--- a/mz.h
+++ b/mz.h
@@ -156,7 +156,7 @@
 
 /***************************************************************************/
 
-#include <stdlib.h> /* size_t, NULL, malloc */
+#include <stdlib.h> /* size_t, NULL, malloc, calloc, free, realloc */
 #include <time.h>   /* time_t, time() */
 #include <string.h> /* memset, strncpy, strlen */
 #include <limits.h>
@@ -271,6 +271,62 @@ typedef unsigned long long uint64_t;
 #ifndef UINT64_MAX
 #  define UINT64_MAX 18446744073709551615ULL
 #endif
+
+/***************************************************************************/
+
+typedef void *(*mz_alloc_func)(void *opaque, uint32_t items, uint32_t size);
+typedef void (*mz_free_func)(void *opaque, void *address);
+typedef void *(*mz_realloc_func)(void *opaque, void *address, uint32_t items, uint32_t size);
+typedef char *(*mz_strdup_func)(void *opaque, const char *str);
+
+static inline void *mz_default_alloc(void *opaque, uint32_t items, uint32_t size) {
+    MZ_UNUSED(opaque);
+    return calloc(items, (size_t)size);
+}
+
+static inline void mz_default_free(void *opaque, void *address) {
+    MZ_UNUSED(opaque);
+    free(address);
+}
+
+static inline void *mz_default_realloc(void *opaque, void *address, uint32_t items, uint32_t size) {
+    MZ_UNUSED(opaque);
+    return realloc(address, (size_t)items * (size_t)size);
+}
+
+static inline char *mz_default_strdup(void *opaque, const char *str) {
+    size_t len;
+    char *copy;
+    MZ_UNUSED(opaque);
+    if (!str)
+        return NULL;
+    len = strlen(str);
+    copy = (char *)malloc(len + 1);
+    if (copy)
+        memcpy(copy, str, len + 1);
+    return copy;
+}
+
+#define MZ_ALLOC(handle, items, size)                                                                                  \
+    ((handle)->alloc_cb ? (handle)->alloc_cb((handle)->opaque, items, size)                                            \
+                        : mz_default_alloc((handle)->opaque, items, size))
+
+#define MZ_FREE(handle, address)                                                                                       \
+    do {                                                                                                               \
+        if (address) {                                                                                                 \
+            if ((handle)->free_cb)                                                                                     \
+                (handle)->free_cb((handle)->opaque, (address));                                                        \
+            else                                                                                                       \
+                mz_default_free(NULL, (address));                                                                      \
+        }                                                                                                              \
+    } while (0)
+
+#define MZ_REALLOC(handle, address, items, size)                                                                       \
+    ((handle)->realloc_cb ? (handle)->realloc_cb((handle)->opaque, address, items, size)                               \
+                          : mz_default_realloc((handle)->opaque, address, items, size))
+
+#define MZ_STRDUP(handle, str)                                                                                         \
+    ((handle)->strdup_cb ? (handle)->strdup_cb((handle)->opaque, str) : mz_default_strdup((handle)->opaque, str))
 
 /***************************************************************************/
 

--- a/mz_crypt_apple.c
+++ b/mz_crypt_apple.c
@@ -57,6 +57,11 @@ typedef struct mz_crypt_sha_s {
     int32_t error;
     int32_t initialized;
     uint16_t algorithm;
+    mz_alloc_func alloc_cb;
+    mz_free_func free_cb;
+    mz_realloc_func realloc_cb;
+    mz_strdup_func strdup_cb;
+    void *opaque;
 } mz_crypt_sha;
 
 /***************************************************************************/
@@ -194,7 +199,7 @@ void mz_crypt_sha_delete(void **handle) {
     sha = (mz_crypt_sha *)*handle;
     if (sha) {
         mz_crypt_sha_reset(*handle);
-        free(sha);
+        MZ_FREE(sha, sha);
     }
     *handle = NULL;
 }
@@ -205,6 +210,11 @@ typedef struct mz_crypt_aes_s {
     CCCryptorRef crypt;
     int32_t mode;
     int32_t error;
+    mz_alloc_func alloc_cb;
+    mz_free_func free_cb;
+    mz_realloc_func realloc_cb;
+    mz_strdup_func strdup_cb;
+    void *opaque;
 } mz_crypt_aes;
 
 /***************************************************************************/
@@ -410,7 +420,7 @@ void mz_crypt_aes_delete(void **handle) {
     aes = (mz_crypt_aes *)*handle;
     if (aes) {
         mz_crypt_aes_free(*handle);
-        free(aes);
+        MZ_FREE(aes, aes);
     }
     *handle = NULL;
 }
@@ -422,6 +432,11 @@ typedef struct mz_crypt_hmac_s {
     int32_t initialized;
     int32_t error;
     uint16_t algorithm;
+    mz_alloc_func alloc_cb;
+    mz_free_func free_cb;
+    mz_realloc_func realloc_cb;
+    mz_strdup_func strdup_cb;
+    void *opaque;
 } mz_crypt_hmac;
 
 /***************************************************************************/
@@ -516,7 +531,7 @@ void mz_crypt_hmac_delete(void **handle) {
     hmac = (mz_crypt_hmac *)*handle;
     if (hmac) {
         mz_crypt_hmac_free(*handle);
-        free(hmac);
+        MZ_FREE(hmac, hmac);
     }
     *handle = NULL;
 }

--- a/mz_crypt_apple.c
+++ b/mz_crypt_apple.c
@@ -184,7 +184,7 @@ int32_t mz_crypt_sha_set_algorithm(void *handle, uint16_t algorithm) {
 }
 
 void *mz_crypt_sha_create(void) {
-    mz_crypt_sha *sha = (mz_crypt_sha *)calloc(1, sizeof(mz_crypt_sha));
+    mz_crypt_sha *sha = (mz_crypt_sha *)MZ_ALLOC(&mz_global_calloc, 1, (uint32_t)sizeof(mz_crypt_sha));
     if (sha) {
         memset(sha, 0, sizeof(mz_crypt_sha));
         sha->algorithm = MZ_HASH_SHA256;
@@ -199,7 +199,7 @@ void mz_crypt_sha_delete(void **handle) {
     sha = (mz_crypt_sha *)*handle;
     if (sha) {
         mz_crypt_sha_reset(*handle);
-        MZ_FREE(sha, sha);
+        MZ_FREE(&mz_global_calloc, sha);
     }
     *handle = NULL;
 }
@@ -409,7 +409,7 @@ void mz_crypt_aes_set_mode(void *handle, int32_t mode) {
 }
 
 void *mz_crypt_aes_create(void) {
-    mz_crypt_aes *aes = (mz_crypt_aes *)calloc(1, sizeof(mz_crypt_aes));
+    mz_crypt_aes *aes = (mz_crypt_aes *)MZ_ALLOC(&mz_global_calloc, 1, (uint32_t)sizeof(mz_crypt_aes));
     return aes;
 }
 
@@ -420,7 +420,7 @@ void mz_crypt_aes_delete(void **handle) {
     aes = (mz_crypt_aes *)*handle;
     if (aes) {
         mz_crypt_aes_free(*handle);
-        MZ_FREE(aes, aes);
+        MZ_FREE(&mz_global_calloc, aes);
     }
     *handle = NULL;
 }
@@ -518,7 +518,7 @@ int32_t mz_crypt_hmac_copy(void *src_handle, void *target_handle) {
 }
 
 void *mz_crypt_hmac_create(void) {
-    mz_crypt_hmac *hmac = (mz_crypt_hmac *)calloc(1, sizeof(mz_crypt_hmac));
+    mz_crypt_hmac *hmac = (mz_crypt_hmac *)MZ_ALLOC(&mz_global_calloc, 1, (uint32_t)sizeof(mz_crypt_hmac));
     if (hmac)
         hmac->algorithm = MZ_HASH_SHA256;
     return hmac;
@@ -531,7 +531,7 @@ void mz_crypt_hmac_delete(void **handle) {
     hmac = (mz_crypt_hmac *)*handle;
     if (hmac) {
         mz_crypt_hmac_free(*handle);
-        MZ_FREE(hmac, hmac);
+        MZ_FREE(&mz_global_calloc, hmac);
     }
     *handle = NULL;
 }

--- a/mz_crypt_openssl.c
+++ b/mz_crypt_openssl.c
@@ -71,6 +71,11 @@ typedef struct mz_crypt_sha_s {
     unsigned long error;
     int32_t initialized;
     uint16_t algorithm;
+    mz_alloc_func alloc_cb;
+    mz_free_func free_cb;
+    mz_realloc_func realloc_cb;
+    mz_strdup_func strdup_cb;
+    void *opaque;
 } mz_crypt_sha;
 
 /***************************************************************************/
@@ -263,7 +268,7 @@ void mz_crypt_sha_delete(void **handle) {
     sha = (mz_crypt_sha *)*handle;
     if (sha) {
         mz_crypt_sha_free(*handle);
-        free(sha);
+        MZ_FREE(sha, sha);
     }
     *handle = NULL;
 }
@@ -274,6 +279,11 @@ typedef struct mz_crypt_aes_s {
     int32_t mode;
     unsigned long error;
     EVP_CIPHER_CTX *ctx;
+    mz_alloc_func alloc_cb;
+    mz_free_func free_cb;
+    mz_realloc_func realloc_cb;
+    mz_strdup_func strdup_cb;
+    void *opaque;
 } mz_crypt_aes;
 
 /***************************************************************************/
@@ -504,7 +514,7 @@ void mz_crypt_aes_delete(void **handle) {
     aes = (mz_crypt_aes *)*handle;
     if (aes) {
         mz_crypt_aes_free(*handle);
-        free(aes);
+        MZ_FREE(aes, aes);
     }
     *handle = NULL;
 }
@@ -521,6 +531,11 @@ typedef struct mz_crypt_hmac_s {
     unsigned long error;
     int32_t initialized;
     uint16_t algorithm;
+    mz_alloc_func alloc_cb;
+    mz_free_func free_cb;
+    mz_realloc_func realloc_cb;
+    mz_strdup_func strdup_cb;
+    void *opaque;
 } mz_crypt_hmac;
 
 /***************************************************************************/
@@ -719,7 +734,7 @@ void mz_crypt_hmac_delete(void **handle) {
     hmac = (mz_crypt_hmac *)*handle;
     if (hmac) {
         mz_crypt_hmac_free(*handle);
-        free(hmac);
+        MZ_FREE(hmac, hmac);
     }
     *handle = NULL;
 }

--- a/mz_crypt_openssl.c
+++ b/mz_crypt_openssl.c
@@ -255,7 +255,7 @@ int32_t mz_crypt_sha_set_algorithm(void *handle, uint16_t algorithm) {
 }
 
 void *mz_crypt_sha_create(void) {
-    mz_crypt_sha *sha = (mz_crypt_sha *)calloc(1, sizeof(mz_crypt_sha));
+    mz_crypt_sha *sha = (mz_crypt_sha *)MZ_ALLOC(&mz_global_calloc, 1, (uint32_t)sizeof(mz_crypt_sha));
     if (sha)
         sha->algorithm = MZ_HASH_SHA256;
     return sha;
@@ -268,7 +268,7 @@ void mz_crypt_sha_delete(void **handle) {
     sha = (mz_crypt_sha *)*handle;
     if (sha) {
         mz_crypt_sha_free(*handle);
-        MZ_FREE(sha, sha);
+        MZ_FREE(&mz_global_calloc, sha);
     }
     *handle = NULL;
 }
@@ -503,7 +503,7 @@ void mz_crypt_aes_set_mode(void *handle, int32_t mode) {
 }
 
 void *mz_crypt_aes_create(void) {
-    mz_crypt_aes *aes = (mz_crypt_aes *)calloc(1, sizeof(mz_crypt_aes));
+    mz_crypt_aes *aes = (mz_crypt_aes *)MZ_ALLOC(&mz_global_calloc, 1, (uint32_t)sizeof(mz_crypt_aes));
     return aes;
 }
 
@@ -514,7 +514,7 @@ void mz_crypt_aes_delete(void **handle) {
     aes = (mz_crypt_aes *)*handle;
     if (aes) {
         mz_crypt_aes_free(*handle);
-        MZ_FREE(aes, aes);
+        MZ_FREE(&mz_global_calloc, aes);
     }
     *handle = NULL;
 }
@@ -721,7 +721,7 @@ int32_t mz_crypt_hmac_copy(void *src_handle, void *target_handle) {
 }
 
 void *mz_crypt_hmac_create(void) {
-    mz_crypt_hmac *hmac = (mz_crypt_hmac *)calloc(1, sizeof(mz_crypt_hmac));
+    mz_crypt_hmac *hmac = (mz_crypt_hmac *)MZ_ALLOC(&mz_global_calloc, 1, (uint32_t)sizeof(mz_crypt_hmac));
     if (hmac)
         hmac->algorithm = MZ_HASH_SHA256;
     return hmac;
@@ -734,7 +734,7 @@ void mz_crypt_hmac_delete(void **handle) {
     hmac = (mz_crypt_hmac *)*handle;
     if (hmac) {
         mz_crypt_hmac_free(*handle);
-        MZ_FREE(hmac, hmac);
+        MZ_FREE(&mz_global_calloc, hmac);
     }
     *handle = NULL;
 }

--- a/mz_crypt_winvista.c
+++ b/mz_crypt_winvista.c
@@ -184,7 +184,7 @@ int32_t mz_crypt_sha_set_algorithm(void *handle, uint16_t algorithm) {
 }
 
 void *mz_crypt_sha_create(void) {
-    mz_crypt_sha *sha = (mz_crypt_sha *)calloc(1, sizeof(mz_crypt_sha));
+    mz_crypt_sha *sha = (mz_crypt_sha *)MZ_ALLOC(&mz_global_calloc, 1, (uint32_t)sizeof(mz_crypt_sha));
     if (sha)
         sha->algorithm = MZ_HASH_SHA256;
     return sha;
@@ -197,7 +197,7 @@ void mz_crypt_sha_delete(void **handle) {
     sha = (mz_crypt_sha *)*handle;
     if (sha) {
         mz_crypt_sha_free(*handle);
-        MZ_FREE(sha, sha);
+        MZ_FREE(&mz_global_calloc, sha);
     }
     *handle = NULL;
 }
@@ -496,7 +496,7 @@ void mz_crypt_aes_set_mode(void *handle, int32_t mode) {
 }
 
 void *mz_crypt_aes_create(void) {
-    mz_crypt_aes *aes = (mz_crypt_aes *)calloc(1, sizeof(mz_crypt_aes));
+    mz_crypt_aes *aes = (mz_crypt_aes *)MZ_ALLOC(&mz_global_calloc, 1, (uint32_t)sizeof(mz_crypt_aes));
     return aes;
 }
 
@@ -507,7 +507,7 @@ void mz_crypt_aes_delete(void **handle) {
     aes = (mz_crypt_aes *)*handle;
     if (aes) {
         mz_crypt_aes_free(*handle);
-        free(aes);
+        MZ_FREE(&mz_global_calloc, aes);
     }
     *handle = NULL;
 }
@@ -646,7 +646,7 @@ int32_t mz_crypt_hmac_copy(void *src_handle, void *target_handle) {
 }
 
 void *mz_crypt_hmac_create(void) {
-    mz_crypt_hmac *hmac = (mz_crypt_hmac *)calloc(1, sizeof(mz_crypt_hmac));
+    mz_crypt_hmac *hmac = (mz_crypt_hmac *)MZ_ALLOC(&mz_global_calloc, 1, (uint32_t)sizeof(mz_crypt_hmac));
     if (hmac)
         hmac->algorithm = MZ_HASH_SHA256;
     return hmac;
@@ -659,7 +659,7 @@ void mz_crypt_hmac_delete(void **handle) {
     hmac = (mz_crypt_hmac *)*handle;
     if (hmac) {
         mz_crypt_hmac_free(*handle);
-        free(hmac);
+        MZ_FREE(&mz_global_calloc, hmac);
     }
     *handle = NULL;
 }

--- a/mz_crypt_winvista.c
+++ b/mz_crypt_winvista.c
@@ -54,6 +54,11 @@ typedef struct mz_crypt_sha_s {
     };
     int32_t error;
     uint16_t algorithm;
+    mz_alloc_func alloc_cb;
+    mz_free_func free_cb;
+    mz_realloc_func realloc_cb;
+    mz_strdup_func strdup_cb;
+    void *opaque;
 } mz_crypt_sha;
 
 /***************************************************************************/
@@ -66,7 +71,7 @@ static void mz_crypt_sha_free(void *handle) {
     if (sha->provider)
         BCryptCloseAlgorithmProvider(sha->provider, 0);
     sha->provider = NULL;
-    free(sha->buffer);
+    MZ_FREE(sha, sha->buffer);
     sha->buffer = NULL;
 }
 
@@ -108,7 +113,7 @@ int32_t mz_crypt_sha_begin(void *handle) {
             BCryptGetProperty(sha->provider, BCRYPT_OBJECT_LENGTH, (PUCHAR)&buffer_size, result_size, &result_size, 0);
     }
     if (NT_SUCCESS(status)) {
-        sha->buffer = malloc(buffer_size);
+        sha->buffer = MZ_ALLOC(sha, 1, (uint32_t)buffer_size);
         if (!sha->buffer)
             return MZ_MEM_ERROR;
         status = BCryptCreateHash(sha->provider, &sha->hash, sha->buffer, buffer_size, NULL, 0, 0);
@@ -192,7 +197,7 @@ void mz_crypt_sha_delete(void **handle) {
     sha = (mz_crypt_sha *)*handle;
     if (sha) {
         mz_crypt_sha_free(*handle);
-        free(sha);
+        MZ_FREE(sha, sha);
     }
     *handle = NULL;
 }

--- a/mz_crypt_winxp.c
+++ b/mz_crypt_winxp.c
@@ -180,7 +180,7 @@ int32_t mz_crypt_sha_set_algorithm(void *handle, uint16_t algorithm) {
 }
 
 void *mz_crypt_sha_create(void) {
-    mz_crypt_sha *sha = (mz_crypt_sha *)calloc(1, sizeof(mz_crypt_sha));
+    mz_crypt_sha *sha = (mz_crypt_sha *)MZ_ALLOC(&mz_global_calloc, 1, (uint32_t)sizeof(mz_crypt_sha));
     if (sha)
         sha->algorithm = MZ_HASH_SHA256;
     return sha;
@@ -193,7 +193,7 @@ void mz_crypt_sha_delete(void **handle) {
     sha = (mz_crypt_sha *)*handle;
     if (sha) {
         mz_crypt_sha_free(*handle);
-        MZ_FREE(sha, sha);
+        MZ_FREE(&mz_global_calloc, sha);
     }
     *handle = NULL;
 }
@@ -370,7 +370,7 @@ void mz_crypt_aes_set_mode(void *handle, int32_t mode) {
 }
 
 void *mz_crypt_aes_create(void) {
-    mz_crypt_aes *aes = (mz_crypt_aes *)calloc(1, sizeof(mz_crypt_aes));
+    mz_crypt_aes *aes = (mz_crypt_aes *)MZ_ALLOC(&mz_global_calloc, 1, (uint32_t)sizeof(mz_crypt_aes));
     return aes;
 }
 
@@ -381,7 +381,7 @@ void mz_crypt_aes_delete(void **handle) {
     aes = (mz_crypt_aes *)*handle;
     if (aes) {
         mz_crypt_aes_free(*handle);
-        MZ_FREE(aes, aes);
+        MZ_FREE(&mz_global_calloc, aes);
     }
     *handle = NULL;
 }
@@ -562,7 +562,7 @@ int32_t mz_crypt_hmac_copy(void *src_handle, void *target_handle) {
 }
 
 void *mz_crypt_hmac_create(void) {
-    mz_crypt_hmac *hmac = (mz_crypt_hmac *)calloc(1, sizeof(mz_crypt_hmac));
+    mz_crypt_hmac *hmac = (mz_crypt_hmac *)MZ_ALLOC(&mz_global_calloc, 1, (uint32_t)sizeof(mz_crypt_hmac));
     if (hmac)
         hmac->algorithm = MZ_HASH_SHA256;
     return hmac;
@@ -575,7 +575,7 @@ void mz_crypt_hmac_delete(void **handle) {
     hmac = (mz_crypt_hmac *)*handle;
     if (hmac) {
         mz_crypt_hmac_free(*handle);
-        MZ_FREE(hmac, hmac);
+        MZ_FREE(&mz_global_calloc, hmac);
     }
     *handle = NULL;
 }

--- a/mz_crypt_winxp.c
+++ b/mz_crypt_winxp.c
@@ -45,6 +45,11 @@ typedef struct mz_crypt_sha_s {
     };
     int32_t error;
     uint16_t algorithm;
+    mz_alloc_func alloc_cb;
+    mz_free_func free_cb;
+    mz_realloc_func realloc_cb;
+    mz_strdup_func strdup_cb;
+    void *opaque;
 } mz_crypt_sha;
 
 /***************************************************************************/
@@ -188,7 +193,7 @@ void mz_crypt_sha_delete(void **handle) {
     sha = (mz_crypt_sha *)*handle;
     if (sha) {
         mz_crypt_sha_free(*handle);
-        free(sha);
+        MZ_FREE(sha, sha);
     }
     *handle = NULL;
 }
@@ -200,6 +205,11 @@ typedef struct mz_crypt_aes_s {
     HCRYPTKEY key;
     int32_t mode;
     int32_t error;
+    mz_alloc_func alloc_cb;
+    mz_free_func free_cb;
+    mz_realloc_func realloc_cb;
+    mz_strdup_func strdup_cb;
+    void *opaque;
 } mz_crypt_aes;
 
 /***************************************************************************/
@@ -298,7 +308,7 @@ static int32_t mz_crypt_aes_set_key(void *handle, const void *key, int32_t key_l
                                  CRYPT_VERIFYCONTEXT | CRYPT_SILENT);
     if (result) {
         key_blob_size = sizeof(key_blob_header_s) + key_length;
-        key_blob = (uint8_t *)malloc(key_blob_size);
+        key_blob = (uint8_t *)MZ_ALLOC(aes, 1, (uint32_t)key_blob_size);
         if (key_blob) {
             key_blob_s = (key_blob_header_s *)key_blob;
             key_blob_s->hdr.bType = PLAINTEXTKEYBLOB;
@@ -312,7 +322,7 @@ static int32_t mz_crypt_aes_set_key(void *handle, const void *key, int32_t key_l
             result = CryptImportKey(aes->provider, key_blob, key_blob_size, 0, 0, &aes->key);
 
             SecureZeroMemory(key_blob, key_blob_size);
-            free(key_blob);
+            MZ_FREE(aes, key_blob);
         } else {
             err = MZ_MEM_ERROR;
         }
@@ -371,7 +381,7 @@ void mz_crypt_aes_delete(void **handle) {
     aes = (mz_crypt_aes *)*handle;
     if (aes) {
         mz_crypt_aes_free(*handle);
-        free(aes);
+        MZ_FREE(aes, aes);
     }
     *handle = NULL;
 }
@@ -386,6 +396,11 @@ typedef struct mz_crypt_hmac_s {
     int32_t mode;
     int32_t error;
     uint16_t algorithm;
+    mz_alloc_func alloc_cb;
+    mz_free_func free_cb;
+    mz_realloc_func realloc_cb;
+    mz_strdup_func strdup_cb;
+    void *opaque;
 } mz_crypt_hmac;
 
 /***************************************************************************/
@@ -449,7 +464,7 @@ int32_t mz_crypt_hmac_init(void *handle, const void *key, int32_t key_length) {
         if (pad_key_length == 1)
             pad_key_length += 1;
         key_blob_size = sizeof(key_blob_header_s) + pad_key_length;
-        key_blob = (uint8_t *)malloc(key_blob_size);
+        key_blob = (uint8_t *)MZ_ALLOC(hmac, 1, (uint32_t)key_blob_size);
     }
 
     if (key_blob) {
@@ -470,7 +485,7 @@ int32_t mz_crypt_hmac_init(void *handle, const void *key, int32_t key_length) {
             result = CryptSetHashParam(hmac->hash, HP_HMAC_INFO, (uint8_t *)&hmac->info, 0);
 
         SecureZeroMemory(key_blob, key_blob_size);
-        free(key_blob);
+        MZ_FREE(hmac, key_blob);
     } else if (err == MZ_OK) {
         err = MZ_MEM_ERROR;
     }
@@ -560,7 +575,7 @@ void mz_crypt_hmac_delete(void **handle) {
     hmac = (mz_crypt_hmac *)*handle;
     if (hmac) {
         mz_crypt_hmac_free(*handle);
-        free(hmac);
+        MZ_FREE(hmac, hmac);
     }
     *handle = NULL;
 }

--- a/mz_strm.c
+++ b/mz_strm.c
@@ -15,6 +15,17 @@
 
 #define MZ_STREAM_FIND_SIZE (1024)
 
+mz_calloc mz_global_calloc = {NULL, NULL, NULL, NULL, NULL};
+
+void mz_set_default_alloc_funcs(mz_alloc_func alloc, mz_free_func free_fn, mz_realloc_func realloc_fn,
+                                mz_strdup_func strdup_fn, void *opaque) {
+    mz_global_calloc.alloc_cb = alloc;
+    mz_global_calloc.free_cb = free_fn;
+    mz_global_calloc.realloc_cb = realloc_fn;
+    mz_global_calloc.strdup_cb = strdup_fn;
+    mz_global_calloc.opaque = opaque;
+}
+
 /***************************************************************************/
 
 int32_t mz_stream_open(void *stream, const char *path, int32_t mode) {
@@ -541,7 +552,7 @@ static mz_stream_vtbl mz_stream_raw_vtbl = {
 /***************************************************************************/
 
 void *mz_stream_raw_create(void) {
-    mz_stream_raw *raw = (mz_stream_raw *)calloc(1, sizeof(mz_stream_raw));
+    mz_stream_raw *raw = (mz_stream_raw *)MZ_ALLOC(&mz_global_calloc, 1, (uint32_t)sizeof(mz_stream_raw));
     if (raw) {
         raw->stream.vtbl = &mz_stream_raw_vtbl;
     }
@@ -553,6 +564,6 @@ void mz_stream_raw_delete(void **stream) {
     if (!stream)
         return;
     raw = (mz_stream_raw *)*stream;
-    free(raw);
+    MZ_FREE(&mz_global_calloc, raw);
     *stream = NULL;
 }

--- a/mz_strm.c
+++ b/mz_strm.c
@@ -418,6 +418,18 @@ void mz_stream_delete(void **stream) {
     *stream = NULL;
 }
 
+void mz_stream_set_alloc_funcs(void *stream, mz_alloc_func alloc, mz_free_func free_fn, mz_realloc_func realloc_fn,
+                               mz_strdup_func strdup_fn, void *opaque) {
+    mz_stream *strm = (mz_stream *)stream;
+    if (!strm)
+        return;
+    strm->alloc_cb = alloc;
+    strm->free_cb = free_fn;
+    strm->realloc_cb = realloc_fn;
+    strm->strdup_cb = strdup_fn;
+    strm->opaque = opaque;
+}
+
 /***************************************************************************/
 
 typedef struct mz_stream_raw_s {
@@ -530,8 +542,9 @@ static mz_stream_vtbl mz_stream_raw_vtbl = {
 
 void *mz_stream_raw_create(void) {
     mz_stream_raw *raw = (mz_stream_raw *)calloc(1, sizeof(mz_stream_raw));
-    if (raw)
+    if (raw) {
         raw->stream.vtbl = &mz_stream_raw_vtbl;
+    }
     return raw;
 }
 

--- a/mz_strm.h
+++ b/mz_strm.h
@@ -70,6 +70,11 @@ typedef struct mz_stream_vtbl_s {
 typedef struct mz_stream_s {
     mz_stream_vtbl *vtbl;
     struct mz_stream_s *base;
+    mz_alloc_func alloc_cb;
+    mz_free_func free_cb;
+    mz_realloc_func realloc_cb;
+    mz_strdup_func strdup_cb;
+    void *opaque;
 } mz_stream;
 
 /***************************************************************************/
@@ -108,6 +113,8 @@ int32_t mz_stream_set_prop_int64(void *stream, int32_t prop, int64_t value);
 
 void *mz_stream_create(mz_stream_vtbl *vtbl);
 void mz_stream_delete(void **stream);
+void mz_stream_set_alloc_funcs(void *stream, mz_alloc_func alloc, mz_free_func free_fn, mz_realloc_func realloc_fn,
+                               mz_strdup_func strdup_fn, void *opaque);
 
 /***************************************************************************/
 

--- a/mz_strm_buf.c
+++ b/mz_strm_buf.c
@@ -361,7 +361,8 @@ int32_t mz_stream_buffered_error(void *stream) {
 }
 
 void *mz_stream_buffered_create(void) {
-    mz_stream_buffered *buffered = (mz_stream_buffered *)calloc(1, sizeof(mz_stream_buffered));
+    mz_stream_buffered *buffered =
+        (mz_stream_buffered *)MZ_ALLOC(&mz_global_calloc, 1, (uint32_t)sizeof(mz_stream_buffered));
     if (buffered)
         buffered->stream.vtbl = &mz_stream_buffered_vtbl;
     return buffered;
@@ -372,7 +373,7 @@ void mz_stream_buffered_delete(void **stream) {
     if (!stream)
         return;
     buffered = (mz_stream_buffered *)*stream;
-    MZ_FREE((mz_stream *)buffered, buffered);
+    MZ_FREE(&mz_global_calloc, buffered);
     *stream = NULL;
 }
 

--- a/mz_strm_buf.c
+++ b/mz_strm_buf.c
@@ -372,7 +372,7 @@ void mz_stream_buffered_delete(void **stream) {
     if (!stream)
         return;
     buffered = (mz_stream_buffered *)*stream;
-    free(buffered);
+    MZ_FREE((mz_stream *)buffered, buffered);
     *stream = NULL;
 }
 

--- a/mz_strm_bzip.c
+++ b/mz_strm_bzip.c
@@ -336,7 +336,7 @@ void mz_stream_bzip_delete(void **stream) {
     if (!stream)
         return;
     bzip = (mz_stream_bzip *)*stream;
-    free(bzip);
+    MZ_FREE((mz_stream *)bzip, bzip);
     *stream = NULL;
 }
 

--- a/mz_strm_bzip.c
+++ b/mz_strm_bzip.c
@@ -323,7 +323,7 @@ int32_t mz_stream_bzip_set_prop_int64(void *stream, int32_t prop, int64_t value)
 }
 
 void *mz_stream_bzip_create(void) {
-    mz_stream_bzip *bzip = (mz_stream_bzip *)calloc(1, sizeof(mz_stream_bzip));
+    mz_stream_bzip *bzip = (mz_stream_bzip *)MZ_ALLOC(&mz_global_calloc, 1, (uint32_t)sizeof(mz_stream_bzip));
     if (bzip) {
         bzip->stream.vtbl = &mz_stream_bzip_vtbl;
         bzip->level = 6;
@@ -336,7 +336,7 @@ void mz_stream_bzip_delete(void **stream) {
     if (!stream)
         return;
     bzip = (mz_stream_bzip *)*stream;
-    MZ_FREE((mz_stream *)bzip, bzip);
+    MZ_FREE(&mz_global_calloc, bzip);
     *stream = NULL;
 }
 

--- a/mz_strm_libcomp.c
+++ b/mz_strm_libcomp.c
@@ -317,7 +317,8 @@ int32_t mz_stream_libcomp_set_prop_int64(void *stream, int32_t prop, int64_t val
 }
 
 void *mz_stream_libcomp_create(void) {
-    mz_stream_libcomp *libcomp = (mz_stream_libcomp *)calloc(1, sizeof(mz_stream_libcomp));
+    mz_stream_libcomp *libcomp =
+        (mz_stream_libcomp *)MZ_ALLOC(&mz_global_calloc, 1, (uint32_t)sizeof(mz_stream_libcomp));
     if (libcomp)
         libcomp->stream.vtbl = &mz_stream_libcomp_vtbl;
     return libcomp;
@@ -329,6 +330,6 @@ void mz_stream_libcomp_delete(void **stream) {
         return;
     libcomp = (mz_stream_libcomp *)*stream;
     if (libcomp)
-        MZ_FREE((mz_stream *)libcomp, libcomp);
+        MZ_FREE(&mz_global_calloc, libcomp);
     *stream = NULL;
 }

--- a/mz_strm_libcomp.c
+++ b/mz_strm_libcomp.c
@@ -329,6 +329,6 @@ void mz_stream_libcomp_delete(void **stream) {
         return;
     libcomp = (mz_stream_libcomp *)*stream;
     if (libcomp)
-        free(libcomp);
+        MZ_FREE((mz_stream *)libcomp, libcomp);
     *stream = NULL;
 }

--- a/mz_strm_lzma.c
+++ b/mz_strm_lzma.c
@@ -428,7 +428,7 @@ int32_t mz_stream_lzma_set_prop_int64(void *stream, int32_t prop, int64_t value)
 }
 
 void *mz_stream_lzma_create(void) {
-    mz_stream_lzma *lzma = (mz_stream_lzma *)calloc(1, sizeof(mz_stream_lzma));
+    mz_stream_lzma *lzma = (mz_stream_lzma *)MZ_ALLOC(&mz_global_calloc, 1, (uint32_t)sizeof(mz_stream_lzma));
     if (lzma) {
         lzma->stream.vtbl = &mz_stream_lzma_vtbl;
         lzma->method = MZ_COMPRESS_METHOD_LZMA;
@@ -443,7 +443,7 @@ void mz_stream_lzma_delete(void **stream) {
     if (!stream)
         return;
     lzma = (mz_stream_lzma *)*stream;
-    MZ_FREE((mz_stream *)lzma, lzma);
+    MZ_FREE(&mz_global_calloc, lzma);
     *stream = NULL;
 }
 

--- a/mz_strm_lzma.c
+++ b/mz_strm_lzma.c
@@ -443,7 +443,7 @@ void mz_stream_lzma_delete(void **stream) {
     if (!stream)
         return;
     lzma = (mz_stream_lzma *)*stream;
-    free(lzma);
+    MZ_FREE((mz_stream *)lzma, lzma);
     *stream = NULL;
 }
 

--- a/mz_strm_mem.c
+++ b/mz_strm_mem.c
@@ -60,7 +60,7 @@ static int32_t mz_stream_mem_set_size(void *stream, int32_t size) {
 
     if (mem->buffer) {
         memcpy(new_buf, mem->buffer, mem->size);
-        free(mem->buffer);
+        MZ_FREE((mz_stream *)stream, mem->buffer);
     }
 
     mem->buffer = new_buf;
@@ -239,7 +239,7 @@ void mz_stream_mem_set_grow_size(void *stream, int32_t grow_size) {
 }
 
 void *mz_stream_mem_create(void) {
-    mz_stream_mem *mem = (mz_stream_mem *)calloc(1, sizeof(mz_stream_mem));
+    mz_stream_mem *mem = (mz_stream_mem *)MZ_ALLOC(&mz_global_calloc, 1, (uint32_t)sizeof(mz_stream_mem));
     if (mem) {
         mem->stream.vtbl = &mz_stream_mem_vtbl;
         mem->grow_size = 4096;
@@ -255,7 +255,7 @@ void mz_stream_mem_delete(void **stream) {
     if (mem) {
         if ((mem->mode & MZ_OPEN_MODE_CREATE) && (mem->buffer))
             MZ_FREE((mz_stream *)mem, mem->buffer);
-        MZ_FREE((mz_stream *)mem, mem);
+        MZ_FREE(&mz_global_calloc, mem);
     }
     *stream = NULL;
 }

--- a/mz_strm_mem.c
+++ b/mz_strm_mem.c
@@ -54,7 +54,7 @@ static int32_t mz_stream_mem_set_size(void *stream, int32_t size) {
     int32_t new_size = size;
     uint8_t *new_buf = NULL;
 
-    new_buf = (uint8_t *)malloc((uint32_t)new_size);
+    new_buf = (uint8_t *)MZ_ALLOC((mz_stream *)stream, 1, (uint32_t)new_size);
     if (!new_buf)
         return MZ_BUF_ERROR;
 
@@ -254,8 +254,8 @@ void mz_stream_mem_delete(void **stream) {
     mem = (mz_stream_mem *)*stream;
     if (mem) {
         if ((mem->mode & MZ_OPEN_MODE_CREATE) && (mem->buffer))
-            free(mem->buffer);
-        free(mem);
+            MZ_FREE((mz_stream *)mem, mem->buffer);
+        MZ_FREE((mz_stream *)mem, mem);
     }
     *stream = NULL;
 }

--- a/mz_strm_os_posix.c
+++ b/mz_strm_os_posix.c
@@ -192,7 +192,7 @@ int32_t mz_stream_os_error(void *stream) {
 }
 
 void *mz_stream_os_create(void) {
-    mz_stream_posix *posix = (mz_stream_posix *)calloc(1, sizeof(mz_stream_posix));
+    mz_stream_posix *posix = (mz_stream_posix *)MZ_ALLOC(&mz_global_calloc, 1, (uint32_t)sizeof(mz_stream_posix));
     if (posix)
         posix->stream.vtbl = &mz_stream_os_vtbl;
     return posix;
@@ -203,7 +203,7 @@ void mz_stream_os_delete(void **stream) {
     if (!stream)
         return;
     posix = (mz_stream_posix *)*stream;
-    MZ_FREE((mz_stream *)posix, posix);
+    MZ_FREE(&mz_global_calloc, posix);
     *stream = NULL;
 }
 

--- a/mz_strm_os_posix.c
+++ b/mz_strm_os_posix.c
@@ -203,7 +203,7 @@ void mz_stream_os_delete(void **stream) {
     if (!stream)
         return;
     posix = (mz_stream_posix *)*stream;
-    free(posix);
+    MZ_FREE((mz_stream *)posix, posix);
     *stream = NULL;
 }
 

--- a/mz_strm_os_win32.c
+++ b/mz_strm_os_win32.c
@@ -259,7 +259,7 @@ int32_t mz_stream_os_error(void *stream) {
 }
 
 void *mz_stream_os_create(void) {
-    mz_stream_win32 *win32 = (mz_stream_win32 *)calloc(1, sizeof(mz_stream_win32));
+    mz_stream_win32 *win32 = (mz_stream_win32 *)MZ_ALLOC(&mz_global_calloc, 1, (uint32_t)sizeof(mz_stream_win32));
     if (win32)
         win32->stream.vtbl = &mz_stream_os_vtbl;
     return win32;
@@ -271,7 +271,7 @@ void mz_stream_os_delete(void **stream) {
         return;
     win32 = (mz_stream_win32 *)*stream;
     if (win32)
-        MZ_FREE((mz_stream *)win32, win32);
+        MZ_FREE(&mz_global_calloc, win32);
     *stream = NULL;
 }
 

--- a/mz_strm_os_win32.c
+++ b/mz_strm_os_win32.c
@@ -271,7 +271,7 @@ void mz_stream_os_delete(void **stream) {
         return;
     win32 = (mz_stream_win32 *)*stream;
     if (win32)
-        free(win32);
+        MZ_FREE((mz_stream *)win32, win32);
     *stream = NULL;
 }
 

--- a/mz_strm_pkcrypt.c
+++ b/mz_strm_pkcrypt.c
@@ -304,7 +304,8 @@ int32_t mz_stream_pkcrypt_set_prop_int64(void *stream, int32_t prop, int64_t val
 }
 
 void *mz_stream_pkcrypt_create(void) {
-    mz_stream_pkcrypt *pkcrypt = (mz_stream_pkcrypt *)calloc(1, sizeof(mz_stream_pkcrypt));
+    mz_stream_pkcrypt *pkcrypt =
+        (mz_stream_pkcrypt *)MZ_ALLOC(&mz_global_calloc, 1, (uint32_t)sizeof(mz_stream_pkcrypt));
     if (pkcrypt)
         pkcrypt->stream.vtbl = &mz_stream_pkcrypt_vtbl;
     return pkcrypt;
@@ -315,7 +316,7 @@ void mz_stream_pkcrypt_delete(void **stream) {
     if (!stream)
         return;
     pkcrypt = (mz_stream_pkcrypt *)*stream;
-    MZ_FREE((mz_stream *)pkcrypt, pkcrypt);
+    MZ_FREE(&mz_global_calloc, pkcrypt);
     *stream = NULL;
 }
 

--- a/mz_strm_pkcrypt.c
+++ b/mz_strm_pkcrypt.c
@@ -315,7 +315,7 @@ void mz_stream_pkcrypt_delete(void **stream) {
     if (!stream)
         return;
     pkcrypt = (mz_stream_pkcrypt *)*stream;
-    free(pkcrypt);
+    MZ_FREE((mz_stream *)pkcrypt, pkcrypt);
     *stream = NULL;
 }
 

--- a/mz_strm_ppmd.c
+++ b/mz_strm_ppmd.c
@@ -479,7 +479,7 @@ void mz_stream_ppmd_delete(void **stream) {
     if (!stream)
         return;
     ppmd = (mz_stream_ppmd *)*stream;
-    free(ppmd);
+    MZ_FREE((mz_stream *)ppmd, ppmd);
     *stream = NULL;
 }
 

--- a/mz_strm_ppmd.c
+++ b/mz_strm_ppmd.c
@@ -464,7 +464,7 @@ int32_t mz_stream_ppmd_set_prop_int64(void *stream, int32_t prop, int64_t value)
 }
 
 void *mz_stream_ppmd_create(void) {
-    mz_stream_ppmd *ppmd = (mz_stream_ppmd *)calloc(1, sizeof(mz_stream_ppmd));
+    mz_stream_ppmd *ppmd = (mz_stream_ppmd *)MZ_ALLOC(&mz_global_calloc, 1, (uint32_t)sizeof(mz_stream_ppmd));
     if (ppmd) {
         ppmd->stream.vtbl = &mz_stream_ppmd_vtbl;
         ppmd->allocator.Alloc = mz_ppmd_alloc_func;
@@ -479,7 +479,7 @@ void mz_stream_ppmd_delete(void **stream) {
     if (!stream)
         return;
     ppmd = (mz_stream_ppmd *)*stream;
-    MZ_FREE((mz_stream *)ppmd, ppmd);
+    MZ_FREE(&mz_global_calloc, ppmd);
     *stream = NULL;
 }
 

--- a/mz_strm_split.c
+++ b/mz_strm_split.c
@@ -392,7 +392,7 @@ int32_t mz_stream_split_set_prop_int64(void *stream, int32_t prop, int64_t value
 }
 
 void *mz_stream_split_create(void) {
-    mz_stream_split *split = (mz_stream_split *)calloc(1, sizeof(mz_stream_split));
+    mz_stream_split *split = (mz_stream_split *)MZ_ALLOC(&mz_global_calloc, 1, (uint32_t)sizeof(mz_stream_split));
     if (split)
         split->stream.vtbl = &mz_stream_split_vtbl;
     return split;
@@ -406,7 +406,7 @@ void mz_stream_split_delete(void **stream) {
     if (split) {
         MZ_FREE((mz_stream *)split, split->path_cd);
         MZ_FREE((mz_stream *)split, split->path_disk);
-        MZ_FREE((mz_stream *)split, split);
+        MZ_FREE(&mz_global_calloc, split);
     }
     *stream = NULL;
 }

--- a/mz_strm_split.c
+++ b/mz_strm_split.c
@@ -175,7 +175,7 @@ int32_t mz_stream_split_open(void *stream, const char *path, int32_t mode) {
     int32_t number_disk = 0;
 
     split->mode = mode;
-    split->path_cd = strdup(path);
+    split->path_cd = MZ_STRDUP((mz_stream *)stream, path);
 
     if (!split->path_cd)
         return MZ_MEM_ERROR;
@@ -183,10 +183,10 @@ int32_t mz_stream_split_open(void *stream, const char *path, int32_t mode) {
     mz_stream_split_print("Split - Open - %s (disk %" PRId32 ")\n", split->path_cd, number_disk);
 
     split->path_disk_size = (uint32_t)strlen(path) + 10;
-    split->path_disk = (char *)malloc(split->path_disk_size);
+    split->path_disk = (char *)MZ_ALLOC((mz_stream *)stream, 1, (uint32_t)split->path_disk_size);
 
     if (!split->path_disk) {
-        free(split->path_cd);
+        MZ_FREE((mz_stream *)stream, split->path_cd);
         return MZ_MEM_ERROR;
     }
 
@@ -404,9 +404,9 @@ void mz_stream_split_delete(void **stream) {
         return;
     split = (mz_stream_split *)*stream;
     if (split) {
-        free(split->path_cd);
-        free(split->path_disk);
-        free(split);
+        MZ_FREE((mz_stream *)split, split->path_cd);
+        MZ_FREE((mz_stream *)split, split->path_disk);
+        MZ_FREE((mz_stream *)split, split);
     }
     *stream = NULL;
 }

--- a/mz_strm_wzaes.c
+++ b/mz_strm_wzaes.c
@@ -317,20 +317,20 @@ int32_t mz_stream_wzaes_set_prop_int64(void *stream, int32_t prop, int64_t value
 }
 
 void *mz_stream_wzaes_create(void) {
-    mz_stream_wzaes *wzaes = (mz_stream_wzaes *)calloc(1, sizeof(mz_stream_wzaes));
+    mz_stream_wzaes *wzaes = (mz_stream_wzaes *)MZ_ALLOC(&mz_global_calloc, 1, (uint32_t)sizeof(mz_stream_wzaes));
     if (wzaes) {
         wzaes->stream.vtbl = &mz_stream_wzaes_vtbl;
         wzaes->strength = MZ_AES_STRENGTH_256;
 
         wzaes->hmac = mz_crypt_hmac_create();
         if (!wzaes->hmac) {
-            MZ_FREE((mz_stream *)wzaes, wzaes);
+            MZ_FREE(&mz_global_calloc, wzaes);
             return NULL;
         }
         wzaes->aes = mz_crypt_aes_create();
         if (!wzaes->aes) {
             mz_crypt_hmac_delete(&wzaes->hmac);
-            MZ_FREE((mz_stream *)wzaes, wzaes);
+            MZ_FREE(&mz_global_calloc, wzaes);
             return NULL;
         }
     }
@@ -345,7 +345,7 @@ void mz_stream_wzaes_delete(void **stream) {
     if (wzaes) {
         mz_crypt_aes_delete(&wzaes->aes);
         mz_crypt_hmac_delete(&wzaes->hmac);
-        MZ_FREE((mz_stream *)wzaes, wzaes);
+        MZ_FREE(&mz_global_calloc, wzaes);
     }
     *stream = NULL;
 }

--- a/mz_strm_wzaes.c
+++ b/mz_strm_wzaes.c
@@ -324,13 +324,13 @@ void *mz_stream_wzaes_create(void) {
 
         wzaes->hmac = mz_crypt_hmac_create();
         if (!wzaes->hmac) {
-            free(wzaes);
+            MZ_FREE((mz_stream *)wzaes, wzaes);
             return NULL;
         }
         wzaes->aes = mz_crypt_aes_create();
         if (!wzaes->aes) {
             mz_crypt_hmac_delete(&wzaes->hmac);
-            free(wzaes);
+            MZ_FREE((mz_stream *)wzaes, wzaes);
             return NULL;
         }
     }
@@ -345,7 +345,7 @@ void mz_stream_wzaes_delete(void **stream) {
     if (wzaes) {
         mz_crypt_aes_delete(&wzaes->aes);
         mz_crypt_hmac_delete(&wzaes->hmac);
-        free(wzaes);
+        MZ_FREE((mz_stream *)wzaes, wzaes);
     }
     *stream = NULL;
 }

--- a/mz_strm_zlib.c
+++ b/mz_strm_zlib.c
@@ -62,17 +62,28 @@ typedef struct mz_stream_zlib_s {
 
 /***************************************************************************/
 
+static void mz_stream_zlib_set_alloc_funcs(void *stream, zlib_stream *zstream) {
+    mz_stream *strm = (mz_stream *)stream;
+    zstream->zalloc = Z_NULL;
+    zstream->zfree = Z_NULL;
+    zstream->opaque = Z_NULL;
+    if (strm->alloc_cb) {
+        zstream->zalloc = (alloc_func)strm->alloc_cb;
+        zstream->zfree = (free_func)strm->free_cb;
+        zstream->opaque = strm->opaque;
+    }
+}
+
 int32_t mz_stream_zlib_open(void *stream, const char *path, int32_t mode) {
     mz_stream_zlib *zlib = (mz_stream_zlib *)stream;
 
     MZ_UNUSED(path);
 
     zlib->zstream.data_type = Z_BINARY;
-    zlib->zstream.zalloc = Z_NULL;
-    zlib->zstream.zfree = Z_NULL;
-    zlib->zstream.opaque = Z_NULL;
     zlib->zstream.total_in = 0;
     zlib->zstream.total_out = 0;
+
+    mz_stream_zlib_set_alloc_funcs(stream, &zlib->zstream);
 
     zlib->total_in = 0;
     zlib->total_out = 0;
@@ -369,7 +380,7 @@ void mz_stream_zlib_delete(void **stream) {
     if (!stream)
         return;
     zlib = (mz_stream_zlib *)*stream;
-    free(zlib);
+    MZ_FREE((mz_stream *)zlib, zlib);
     *stream = NULL;
 }
 

--- a/mz_strm_zlib.c
+++ b/mz_strm_zlib.c
@@ -366,7 +366,7 @@ int32_t mz_stream_zlib_set_prop_int64(void *stream, int32_t prop, int64_t value)
 }
 
 void *mz_stream_zlib_create(void) {
-    mz_stream_zlib *zlib = (mz_stream_zlib *)calloc(1, sizeof(mz_stream_zlib));
+    mz_stream_zlib *zlib = (mz_stream_zlib *)MZ_ALLOC(&mz_global_calloc, 1, (uint32_t)sizeof(mz_stream_zlib));
     if (zlib) {
         zlib->stream.vtbl = &mz_stream_zlib_vtbl;
         zlib->level = Z_DEFAULT_COMPRESSION;
@@ -380,7 +380,7 @@ void mz_stream_zlib_delete(void **stream) {
     if (!stream)
         return;
     zlib = (mz_stream_zlib *)*stream;
-    MZ_FREE((mz_stream *)zlib, zlib);
+    MZ_FREE(&mz_global_calloc, zlib);
     *stream = NULL;
 }
 

--- a/mz_strm_zstd.c
+++ b/mz_strm_zstd.c
@@ -321,7 +321,7 @@ int32_t mz_stream_zstd_set_prop_int64(void *stream, int32_t prop, int64_t value)
 }
 
 void *mz_stream_zstd_create(void) {
-    mz_stream_zstd *zstd = (mz_stream_zstd *)calloc(1, sizeof(mz_stream_zstd));
+    mz_stream_zstd *zstd = (mz_stream_zstd *)MZ_ALLOC(&mz_global_calloc, 1, (uint32_t)sizeof(mz_stream_zstd));
     if (zstd) {
         zstd->stream.vtbl = &mz_stream_zstd_vtbl;
         zstd->max_total_out = -1;
@@ -335,7 +335,7 @@ void mz_stream_zstd_delete(void **stream) {
     if (!stream)
         return;
     zstd = (mz_stream_zstd *)*stream;
-    MZ_FREE((mz_stream *)zstd, zstd);
+    MZ_FREE(&mz_global_calloc, zstd);
     *stream = NULL;
 }
 

--- a/mz_strm_zstd.c
+++ b/mz_strm_zstd.c
@@ -335,7 +335,7 @@ void mz_stream_zstd_delete(void **stream) {
     if (!stream)
         return;
     zstd = (mz_stream_zstd *)*stream;
-    free(zstd);
+    MZ_FREE((mz_stream *)zstd, zstd);
     *stream = NULL;
 }
 

--- a/mz_zip.c
+++ b/mz_zip.c
@@ -117,6 +117,12 @@ typedef struct mz_zip_s {
 
     uint16_t version_madeby;
     char *comment;
+
+    mz_alloc_func alloc_cb;
+    mz_free_func free_cb;
+    mz_realloc_func realloc_cb;
+    mz_strdup_func strdup_cb;
+    void *opaque;
 } mz_zip;
 
 /***************************************************************************/
@@ -395,7 +401,7 @@ static int32_t mz_zip_entry_read_header(void *stream, uint8_t local, mz_zip_file
                    terminated string */
                 linkname_size = field_length - 12;
                 if ((err == MZ_OK) && (linkname_size > 0)) {
-                    linkname = (char *)malloc(linkname_size);
+                    linkname = (char *)MZ_ALLOC((mz_stream *)file_extra_stream, 1, (uint32_t)linkname_size);
                     if (linkname) {
                         if (mz_stream_read(file_extra_stream, linkname, linkname_size) != linkname_size)
                             err = MZ_READ_ERROR;
@@ -408,7 +414,7 @@ static int32_t mz_zip_entry_read_header(void *stream, uint8_t local, mz_zip_file
 
                             mz_stream_seek(file_extra_stream, saved_pos, MZ_SEEK_SET);
                         }
-                        free(linkname);
+                        MZ_FREE((mz_stream *)file_extra_stream, linkname);
                     }
                 }
             }
@@ -1001,7 +1007,7 @@ static int32_t mz_zip_read_cd(void *handle) {
         if (err == MZ_OK)
             err = mz_stream_read_uint16(zip->stream, &comment_size);
         if ((err == MZ_OK) && (comment_size > 0)) {
-            zip->comment = (char *)malloc(comment_size + 1);
+            zip->comment = (char *)MZ_ALLOC(zip, 1, (uint32_t)(comment_size + 1));
             if (zip->comment) {
                 comment_read = mz_stream_read(zip->stream, zip->comment, comment_size);
                 /* Don't fail if incorrect comment length read, not critical */
@@ -1422,7 +1428,7 @@ void mz_zip_delete(void **handle) {
     if (!handle)
         return;
     zip = (mz_zip *)*handle;
-    free(zip);
+    MZ_FREE(zip, zip);
     *handle = NULL;
 }
 
@@ -1539,7 +1545,7 @@ int32_t mz_zip_close(void *handle) {
     }
 
     if (zip->comment) {
-        free(zip->comment);
+        MZ_FREE(zip, zip->comment);
         zip->comment = NULL;
     }
 
@@ -1564,11 +1570,11 @@ int32_t mz_zip_set_comment(void *handle, const char *comment) {
     int32_t comment_size = 0;
     if (!zip || !comment)
         return MZ_PARAM_ERROR;
-    free(zip->comment);
+    MZ_FREE(zip, zip->comment);
     comment_size = (int32_t)strlen(comment);
     if (comment_size > UINT16_MAX)
         return MZ_PARAM_ERROR;
-    zip->comment = (char *)calloc(comment_size + 1, sizeof(char));
+    zip->comment = (char *)MZ_ALLOC(zip, (uint32_t)(comment_size + 1), sizeof(char));
     if (!zip->comment)
         return MZ_MEM_ERROR;
     strncpy(zip->comment, comment, comment_size);
@@ -2829,6 +2835,18 @@ const char *mz_zip_get_compression_method_string(int32_t compression_method) {
         break;
     }
     return method;
+}
+
+void mz_zip_set_alloc_funcs(void *handle, mz_alloc_func alloc, mz_free_func free_fn, mz_realloc_func realloc_fn,
+                            mz_strdup_func strdup_fn, void *opaque) {
+    mz_zip *zip = (mz_zip *)handle;
+    if (!zip)
+        return;
+    zip->alloc_cb = alloc;
+    zip->free_cb = free_fn;
+    zip->realloc_cb = realloc_fn;
+    zip->strdup_cb = strdup_fn;
+    zip->opaque = opaque;
 }
 
 /***************************************************************************/

--- a/mz_zip.c
+++ b/mz_zip.c
@@ -1417,7 +1417,7 @@ static int32_t mz_zip_recover_cd(void *handle) {
 }
 
 void *mz_zip_create(void) {
-    mz_zip *zip = (mz_zip *)calloc(1, sizeof(mz_zip));
+    mz_zip *zip = (mz_zip *)MZ_ALLOC(&mz_global_calloc, 1, (uint32_t)sizeof(mz_zip));
     if (zip)
         zip->data_descriptor = 1;
     return zip;
@@ -1428,7 +1428,7 @@ void mz_zip_delete(void **handle) {
     if (!handle)
         return;
     zip = (mz_zip *)*handle;
-    MZ_FREE(zip, zip);
+    MZ_FREE(&mz_global_calloc, zip);
     *handle = NULL;
 }
 
@@ -1570,10 +1570,10 @@ int32_t mz_zip_set_comment(void *handle, const char *comment) {
     int32_t comment_size = 0;
     if (!zip || !comment)
         return MZ_PARAM_ERROR;
-    MZ_FREE(zip, zip->comment);
     comment_size = (int32_t)strlen(comment);
     if (comment_size > UINT16_MAX)
         return MZ_PARAM_ERROR;
+    MZ_FREE(zip, zip->comment);
     zip->comment = (char *)MZ_ALLOC(zip, (uint32_t)(comment_size + 1), sizeof(char));
     if (!zip->comment)
         return MZ_MEM_ERROR;

--- a/mz_zip.h
+++ b/mz_zip.h
@@ -107,6 +107,10 @@ int32_t mz_zip_set_disk_number_with_cd(void *handle, uint32_t disk_number_with_c
 int32_t mz_zip_get_disk_number_with_cd(void *handle, uint32_t *disk_number_with_cd);
 /* Get the disk number containing the central directory record */
 
+void mz_zip_set_alloc_funcs(void *handle, mz_alloc_func alloc, mz_free_func free_fn, mz_realloc_func realloc_fn,
+                            mz_strdup_func strdup_fn, void *opaque);
+/* Set custom allocator functions for the zip handle */
+
 /***************************************************************************/
 
 int32_t mz_zip_entry_is_open(void *handle);

--- a/mz_zip_rw.c
+++ b/mz_zip_rw.c
@@ -60,6 +60,11 @@ typedef struct mz_zip_reader_s {
     uint8_t entry_verified;
     uint8_t recover;
     const char *destination_dir;
+    mz_alloc_func alloc_cb;
+    mz_free_func free_cb;
+    mz_realloc_func realloc_cb;
+    mz_strdup_func strdup_cb;
+    void *opaque;
 } mz_zip_reader;
 
 /***************************************************************************/
@@ -677,14 +682,14 @@ int32_t mz_zip_reader_entry_save_file(void *handle, const char *path) {
     if (!reader->file_info || !path)
         return MZ_PARAM_ERROR;
 
-    pathwfs = (char *)strdup(path);
+    pathwfs = MZ_STRDUP(reader, path);
     if (!pathwfs)
         return MZ_MEM_ERROR;
 
     if (reader->entry_cb)
         reader->entry_cb(reader, reader->entry_userdata, reader->file_info, pathwfs);
 
-    directory = (char *)strdup(pathwfs);
+    directory = MZ_STRDUP(reader, pathwfs);
     if (!directory) {
         err = MZ_MEM_ERROR;
         goto save_cleanup;
@@ -798,8 +803,8 @@ int32_t mz_zip_reader_entry_save_file(void *handle, const char *path) {
     }
 
 save_cleanup:
-    free(pathwfs);
-    free(directory);
+    MZ_FREE(reader, pathwfs);
+    MZ_FREE(reader, directory);
 
     return err;
 }
@@ -879,19 +884,19 @@ int32_t mz_zip_reader_save_all(void *handle, const char *destination_dir) {
             resolved_name_size += destination_dir_len;
         }
 
-        new_alloc = (char *)realloc(path, resolved_name_size);
+        new_alloc = (char *)MZ_REALLOC(reader, path, 1, (uint32_t)resolved_name_size);
         if (!new_alloc) {
             err = MZ_MEM_ERROR;
             goto save_all_cleanup;
         }
         path = new_alloc;
-        new_alloc = (char *)realloc(utf8_name, utf8_name_size);
+        new_alloc = (char *)MZ_REALLOC(reader, utf8_name, 1, (uint32_t)utf8_name_size);
         if (!new_alloc) {
             err = MZ_MEM_ERROR;
             goto save_all_cleanup;
         }
         utf8_name = new_alloc;
-        new_alloc = (char *)realloc(resolved_name, resolved_name_size);
+        new_alloc = (char *)MZ_REALLOC(reader, resolved_name, 1, (uint32_t)resolved_name_size);
         if (!new_alloc) {
             err = MZ_MEM_ERROR;
             goto save_all_cleanup;
@@ -933,9 +938,9 @@ int32_t mz_zip_reader_save_all(void *handle, const char *destination_dir) {
         err = MZ_OK;
 
 save_all_cleanup:
-    free(path);
-    free(utf8_name);
-    free(resolved_name);
+    MZ_FREE(reader, path);
+    MZ_FREE(reader, utf8_name);
+    MZ_FREE(reader, resolved_name);
 
     return err;
 }
@@ -1071,7 +1076,7 @@ void mz_zip_reader_delete(void **handle) {
     reader = (mz_zip_reader *)*handle;
     if (reader) {
         mz_zip_reader_close(reader);
-        free(reader);
+        MZ_FREE(reader, reader);
     }
     *handle = NULL;
 }
@@ -1107,6 +1112,11 @@ typedef struct mz_zip_writer_s {
     uint8_t aes;
     uint8_t raw;
     uint8_t buffer[UINT16_MAX];
+    mz_alloc_func alloc_cb;
+    mz_free_func free_cb;
+    mz_realloc_func realloc_cb;
+    mz_strdup_func strdup_cb;
+    void *opaque;
 } mz_zip_writer;
 
 /***************************************************************************/
@@ -2027,9 +2037,35 @@ void mz_zip_writer_delete(void **handle) {
     writer = (mz_zip_writer *)*handle;
     if (writer) {
         mz_zip_writer_close(writer);
-        free(writer);
+        MZ_FREE(writer, writer);
     }
     *handle = NULL;
+}
+
+/***************************************************************************/
+
+void mz_zip_reader_set_alloc_funcs(void *handle, mz_alloc_func alloc, mz_free_func free_fn, mz_realloc_func realloc_fn,
+                                   mz_strdup_func strdup_fn, void *opaque) {
+    mz_zip_reader *reader = (mz_zip_reader *)handle;
+    if (!reader)
+        return;
+    reader->alloc_cb = alloc;
+    reader->free_cb = free_fn;
+    reader->realloc_cb = realloc_fn;
+    reader->strdup_cb = strdup_fn;
+    reader->opaque = opaque;
+}
+
+void mz_zip_writer_set_alloc_funcs(void *handle, mz_alloc_func alloc, mz_free_func free_fn, mz_realloc_func realloc_fn,
+                                   mz_strdup_func strdup_fn, void *opaque) {
+    mz_zip_writer *writer = (mz_zip_writer *)handle;
+    if (!writer)
+        return;
+    writer->alloc_cb = alloc;
+    writer->free_cb = free_fn;
+    writer->realloc_cb = realloc_fn;
+    writer->strdup_cb = strdup_fn;
+    writer->opaque = opaque;
 }
 
 /***************************************************************************/

--- a/mz_zip_rw.c
+++ b/mz_zip_rw.c
@@ -1061,7 +1061,7 @@ int32_t mz_zip_reader_get_zip_handle(void *handle, void **zip_handle) {
 /***************************************************************************/
 
 void *mz_zip_reader_create(void) {
-    mz_zip_reader *reader = (mz_zip_reader *)calloc(1, sizeof(mz_zip_reader));
+    mz_zip_reader *reader = (mz_zip_reader *)MZ_ALLOC(&mz_global_calloc, 1, (uint32_t)sizeof(mz_zip_reader));
     if (reader) {
         reader->recover = 1;
         reader->progress_cb_interval_ms = MZ_DEFAULT_PROGRESS_INTERVAL;
@@ -1076,7 +1076,7 @@ void mz_zip_reader_delete(void **handle) {
     reader = (mz_zip_reader *)*handle;
     if (reader) {
         mz_zip_reader_close(reader);
-        MZ_FREE(reader, reader);
+        MZ_FREE(&mz_global_calloc, reader);
     }
     *handle = NULL;
 }
@@ -2008,7 +2008,7 @@ int32_t mz_zip_writer_get_zip_handle(void *handle, void **zip_handle) {
 /***************************************************************************/
 
 void *mz_zip_writer_create(void) {
-    mz_zip_writer *writer = (mz_zip_writer *)calloc(1, sizeof(mz_zip_writer));
+    mz_zip_writer *writer = (mz_zip_writer *)MZ_ALLOC(&mz_global_calloc, 1, (uint32_t)sizeof(mz_zip_writer));
     if (writer) {
 #if defined(HAVE_WZAES)
         writer->aes = 1;
@@ -2037,7 +2037,7 @@ void mz_zip_writer_delete(void **handle) {
     writer = (mz_zip_writer *)*handle;
     if (writer) {
         mz_zip_writer_close(writer);
-        MZ_FREE(writer, writer);
+        MZ_FREE(&mz_global_calloc, writer);
     }
     *handle = NULL;
 }

--- a/mz_zip_rw.h
+++ b/mz_zip_rw.h
@@ -150,6 +150,10 @@ void *mz_zip_reader_create(void);
 void mz_zip_reader_delete(void **handle);
 /* Delete instance of zip reader */
 
+void mz_zip_reader_set_alloc_funcs(void *handle, mz_alloc_func alloc, mz_free_func free_fn, mz_realloc_func realloc_fn,
+                                   mz_strdup_func strdup_fn, void *opaque);
+/* Set custom allocator functions for zip reader */
+
 /***************************************************************************/
 
 typedef int32_t (*mz_zip_writer_overwrite_cb)(void *handle, void *userdata, const char *path);
@@ -271,6 +275,10 @@ void *mz_zip_writer_create(void);
 
 void mz_zip_writer_delete(void **handle);
 /* Delete instance of zip writer */
+
+void mz_zip_writer_set_alloc_funcs(void *handle, mz_alloc_func alloc, mz_free_func free_fn, mz_realloc_func realloc_fn,
+                                   mz_strdup_func strdup_fn, void *opaque);
+/* Set custom allocator functions for zip writer */
 
 /***************************************************************************/
 


### PR DESCRIPTION
Add mz_alloc_func, mz_free_func, mz_realloc_func, mz_strdup_func typedefs and per-instance setters (mz_stream_set_alloc_funcs, mz_zip_set_alloc_funcs, mz_zip_reader_set_alloc_funcs, mz_zip_writer_set_alloc_funcs) that allow applications to override the C standard library allocators. All internal calloc/malloc/free/realloc/strdup calls now route through MZ_ALLOC/MZ_FREE/MZ_REALLOC/MZ_STRDUP macros, falling back to stdlib defaults when no custom allocator is set.
Custom allocators are also propagated to internal zlib-ngstreams.

Resolves #794 